### PR TITLE
[Feat] 로그인 로직 및 토큰 재발급 

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,6 +38,9 @@ reviews:
     enabled: true
     # 이미 리뷰가 진행된 PR에 새로운 커밋이 추가될 때, 변경된 부분에 대해서만 자동으로 리뷰를 진행할지 여부
     auto_incremental_review: true
+    base_branches:
+      - "main"
+      - "develop"
 
 # ---------------------------------------------------------------- #
 # 채팅 기능 설정

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -1,0 +1,9 @@
+package com.capstone.pickIt.api.user.controller;
+
+public class UserController {
+
+
+
+
+
+}

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -16,8 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,57 +33,51 @@ public class UserController {
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
     @PostMapping("/email/send")
-    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
+    public ApiResponse<Void> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
     @PostMapping("/email/verify")
-    public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
+    public ApiResponse<Void> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
+    public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.<UserResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.CREATED.getCode())
-                        .message("회원가입에 성공했습니다.")
-                        .result(response)
-                        .build());
+        return ApiResponse.<UserResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.CREATED.getCode())
+                .message("회원가입에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO request) {
         LoginResponseDTO response = authService.login(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("로그인에 성공했습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("로그인에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
         LoginResponseDTO response = authService.refresh(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("토큰이 재발급되었습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("토큰이 재발급되었습니다.")
+                .result(response)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -1,9 +1,29 @@
 package com.capstone.pickIt.api.user.controller;
 
+import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.api.user.service.UserService;
+import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
+import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
 
+    private final UserService userService;
 
-
-
-
+    @PostMapping("/signup") //회원가입 로직
+    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody UserRequestDTO request) {
+        UserResponseDTO response = userService.signUp(request);
+        return ResponseEntity
+                .status(SuccessCode.CREATED.getHttpStatus())
+                .body(ApiResponse.onSuccess(response, SuccessCode.CREATED));
+    }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -2,8 +2,12 @@ package com.capstone.pickIt.api.user.controller;
 
 import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.api.user.service.AuthService;
 import com.capstone.pickIt.api.user.service.EmailService;
 import com.capstone.pickIt.api.user.service.UserService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
@@ -19,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @Tag(name = "User", description = "유저 API")
 @RestController
 @RequestMapping("/api/users")
@@ -28,23 +31,24 @@ public class UserController {
 
     private final UserService userService;
     private final EmailService emailService;
+    private final AuthService authService;
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
-    @PostMapping("/email/send") //이메일 인증 코드 전송
+    @PostMapping("/email/send")
     public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
-    @PostMapping("/email/verify") // 사용자 이메일 인증 코드 확인
+    @PostMapping("/email/verify")
     public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
-    @PostMapping("/signup") // 회원가입
+    @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
         return ResponseEntity
@@ -55,5 +59,33 @@ public class UserController {
                         .message("회원가입에 성공했습니다.")
                         .result(response)
                         .build());
+    }
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+        LoginResponseDTO response = authService.login(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("로그인에 성공했습니다.")
+                        .result(response)
+                        .build()
+        );
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+        LoginResponseDTO response = authService.refresh(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("토큰이 재발급되었습니다.")
+                        .result(response)
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.capstone.pickIt.api.user.controller;
 
+import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.api.user.service.EmailService;
 import com.capstone.pickIt.api.user.service.UserService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
 import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,9 +22,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final EmailService emailService;
 
-    @PostMapping("/signup") //회원가입 로직
-    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody UserRequestDTO request) {
+    @PostMapping("/email/send") //이메일 인증 코드 전송
+    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
+        emailService.sendVerificationCode(request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+    }
+
+    @PostMapping("/email/verify") // 사용자 이메일 인증 코드 확인
+    public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
+        emailService.verifyCode(request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+    }
+
+    @PostMapping("/signup") // 회원가입
+    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
         return ResponseEntity
                 .status(SuccessCode.CREATED.getHttpStatus())

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -8,14 +8,19 @@ import com.capstone.pickIt.api.user.service.EmailService;
 import com.capstone.pickIt.api.user.service.UserService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
 import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@Tag(name = "User", description = "유저 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -24,23 +29,31 @@ public class UserController {
     private final UserService userService;
     private final EmailService emailService;
 
+    @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
     @PostMapping("/email/send") //이메일 인증 코드 전송
     public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
+    @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
     @PostMapping("/email/verify") // 사용자 이메일 인증 코드 확인
     public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
+    @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup") // 회원가입
     public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
         return ResponseEntity
-                .status(SuccessCode.CREATED.getHttpStatus())
-                .body(ApiResponse.onSuccess(response, SuccessCode.CREATED));
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.<UserResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.CREATED.getCode())
+                        .message("회원가입에 성공했습니다.")
+                        .result(response)
+                        .build());
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailSendRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailSendRequestDTO.java
@@ -1,0 +1,13 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailSendRequestDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailSendRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailSendRequestDTO.java
@@ -3,8 +3,10 @@ package com.capstone.pickIt.api.user.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class EmailSendRequestDTO {
 
     @NotBlank

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailVerifyRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailVerifyRequestDTO.java
@@ -1,0 +1,16 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyRequestDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailVerifyRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/EmailVerifyRequestDTO.java
@@ -3,8 +3,10 @@ package com.capstone.pickIt.api.user.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class EmailVerifyRequestDTO {
 
     @NotBlank

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
@@ -1,0 +1,18 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
@@ -1,0 +1,13 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequestDTO {
+
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
@@ -1,0 +1,12 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserRequestDTO {
+
+    private String email;
+    private String password;
+    private String nickname;
+    private String major;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
@@ -1,12 +1,24 @@
 package com.capstone.pickIt.api.user.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserRequestDTO {
 
+    @NotBlank
+    @Email
     private String email;
+
+    @NotBlank
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하여야 합니다.")
     private String password;
+
+    @NotBlank
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
     private String nickname;
-    private String major;
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -10,6 +10,5 @@ public class LoginResponseDTO {
     private String accessToken;
     private String refreshToken;
     private Long userId;
-    private String email;
     private String nickname;
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -1,0 +1,15 @@
+package com.capstone.pickIt.api.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDTO {
+
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/UserResponseDTO.java
@@ -1,0 +1,14 @@
+package com.capstone.pickIt.api.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDTO {
+
+    private Long userId;
+    private String email;
+    private String nickname;
+
+}

--- a/src/main/java/com/capstone/pickIt/api/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/capstone/pickIt/api/user/exception/UserExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.capstone.pickIt.api.user.exception;
+
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(UserException e) {
+        log.error("UserException 발생: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.onFailure(e.getErrorCode(), null));
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+
+public interface AuthService {
+
+    LoginResponseDTO login(LoginRequestDTO request);
+
+    LoginResponseDTO refresh(TokenRefreshRequestDTO request);
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -65,7 +65,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }
@@ -113,7 +112,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -1,0 +1,120 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.infra.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:token:";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh-token-expire-ms}")
+    private long refreshTokenExpireMs;
+
+
+    /**
+     * 사용자 로그인을 처리합니다.
+     * 1. 사용자 존재 여부 및 비밀번호 검증
+     * 2. Access/Refresh 토큰 생성
+     * 3. Refresh 토큰을 Redis에 저장 (추후 갱신 및 로그아웃용)
+     */
+    @Override
+    public LoginResponseDTO login(LoginRequestDTO request) {
+
+        //이메일로 사용자 조회하기
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        }
+
+        //jwt 토큰 발급
+        String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
+
+        // refresh 토큰을 레디스에 저장
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                refreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    /**
+     * Access 토큰 만료 시 Refresh 토큰을 통해 새로운 토큰 쌍을 발급합니다.
+     * Refresh Token Rotation 전략을 사용하여 보안을 강화합니다.
+     */
+    @Override
+    public LoginResponseDTO refresh(TokenRefreshRequestDTO request) {
+        String refreshToken = request.getRefreshToken();
+
+        //전달 받은 refresh 토큰의 유효성 검증하기
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        // 토큰에서 유저 정보 추출하기
+        Long userId = jwtProvider.getMemberId(refreshToken);
+        String email = jwtProvider.getEmail(refreshToken);
+
+        //레디스에 저장된 토큰하고 일치하는지 확인하기
+        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+        if (!refreshToken.equals(storedToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        //유저 존재 여부 재확인하기
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        //새로운 토큰 쌍 생성하기 기존 토큰은 무효화하고 새롭게 발급해주는 것
+        String newAccessToken = jwtProvider.createAccessToken(userId, email);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId, email);
+
+        //레디스에 새로운 refresh토큰 갱신하기
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + userId,
+                newRefreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/EmailService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/EmailService.java
@@ -2,76 +2,10 @@ package com.capstone.pickIt.api.user.service;
 
 import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
-import com.capstone.pickIt.domain.user.exception.UserErrorCode;
-import com.capstone.pickIt.global.apiPayload.exception.CustomException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Service;
 
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
+public interface EmailService {
 
-@Service
-@RequiredArgsConstructor
-public class EmailService {
+    void sendVerificationCode(EmailSendRequestDTO request);
 
-    private static final String EMAIL_CODE_PREFIX = "email:code:";
-    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
-    private static final long CODE_TTL_MINUTES = 5;
-    private static final long VERIFIED_TTL_MINUTES = 30;
-
-    private final JavaMailSender mailSender;
-    private final RedisTemplate<String, String> redisTemplate;
-
-    public void sendVerificationCode(EmailSendRequestDTO request) {
-        String email = request.getEmail();
-        String code = generateCode();
-
-        redisTemplate.opsForValue().set(
-                EMAIL_CODE_PREFIX + email,
-                code,
-                CODE_TTL_MINUTES,
-                TimeUnit.MINUTES
-        );
-
-        sendEmail(email, code);
-    }
-
-    public void verifyCode(EmailVerifyRequestDTO request) {
-        String email = request.getEmail();
-        String storedCode = redisTemplate.opsForValue().get(EMAIL_CODE_PREFIX + email);
-
-        if (storedCode == null || !storedCode.equals(request.getCode())) {
-            throw new CustomException(UserErrorCode.EMAIL_CODE_INVALID);
-        }
-
-        redisTemplate.delete(EMAIL_CODE_PREFIX + email);
-        redisTemplate.opsForValue().set(
-                EMAIL_VERIFIED_PREFIX + email,
-                "true",
-                VERIFIED_TTL_MINUTES,
-                TimeUnit.MINUTES
-        );
-    }
-
-    @Async
-    protected void sendEmail(String to, String code) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(to);
-        message.setSubject("[PickIt] 이메일 인증 코드");
-        message.setText(
-                "안녕하세요, PickIt입니다.\n\n" +
-                "인증 코드: " + code + "\n\n" +
-                "유효 시간은 5분입니다.\n" +
-                "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
-        );
-        mailSender.send(message);
-    }
-
-    private String generateCode() {
-        return String.format("%06d", new SecureRandom().nextInt(1_000_000));
-    }
+    void verifyCode(EmailVerifyRequestDTO request);
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/EmailService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/EmailService.java
@@ -1,0 +1,77 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private static final String EMAIL_CODE_PREFIX = "email:code:";
+    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
+    private static final long CODE_TTL_MINUTES = 5;
+    private static final long VERIFIED_TTL_MINUTES = 30;
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void sendVerificationCode(EmailSendRequestDTO request) {
+        String email = request.getEmail();
+        String code = generateCode();
+
+        redisTemplate.opsForValue().set(
+                EMAIL_CODE_PREFIX + email,
+                code,
+                CODE_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        sendEmail(email, code);
+    }
+
+    public void verifyCode(EmailVerifyRequestDTO request) {
+        String email = request.getEmail();
+        String storedCode = redisTemplate.opsForValue().get(EMAIL_CODE_PREFIX + email);
+
+        if (storedCode == null || !storedCode.equals(request.getCode())) {
+            throw new CustomException(UserErrorCode.EMAIL_CODE_INVALID);
+        }
+
+        redisTemplate.delete(EMAIL_CODE_PREFIX + email);
+        redisTemplate.opsForValue().set(
+                EMAIL_VERIFIED_PREFIX + email,
+                "true",
+                VERIFIED_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+    }
+
+    @Async
+    protected void sendEmail(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[PickIt] 이메일 인증 코드");
+        message.setText(
+                "안녕하세요, PickIt입니다.\n\n" +
+                "인증 코드: " + code + "\n\n" +
+                "유효 시간은 5분입니다.\n" +
+                "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
+        );
+        mailSender.send(message);
+    }
+
+    private String generateCode() {
+        return String.format("%06d", new SecureRandom().nextInt(1_000_000));
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/EmailServiceImpl.java
@@ -3,7 +3,7 @@ package com.capstone.pickIt.api.user.service;
 import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
 import com.capstone.pickIt.domain.user.exception.UserErrorCode;
-import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+import com.capstone.pickIt.domain.user.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
@@ -49,7 +49,7 @@ public class EmailServiceImpl implements EmailService {
         String storedCode = redisTemplate.opsForValue().get(EMAIL_CODE_PREFIX + email);
 
         if (storedCode == null || !storedCode.equals(request.getCode())) {
-            throw new CustomException(UserErrorCode.EMAIL_CODE_INVALID);
+            throw new UserException(UserErrorCode.EMAIL_CODE_INVALID);
         }
 
         redisTemplate.delete(EMAIL_CODE_PREFIX + email);
@@ -78,7 +78,7 @@ public class EmailServiceImpl implements EmailService {
     private void validateUniversityEmail(String email) {
         String domain = email.substring(email.indexOf('@') + 1);
         if (!domain.endsWith(UNIVERSITY_DOMAIN_SUFFIX)) {
-            throw new CustomException(UserErrorCode.EMAIL_DOMAIN_INVALID);
+            throw new UserException(UserErrorCode.EMAIL_DOMAIN_INVALID);
         }
     }
 

--- a/src/main/java/com/capstone/pickIt/api/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/EmailServiceImpl.java
@@ -1,0 +1,88 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private static final String EMAIL_CODE_PREFIX = "email:code:";
+    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
+    private static final long CODE_TTL_MINUTES = 5;
+    private static final long VERIFIED_TTL_MINUTES = 30;
+    private static final String UNIVERSITY_DOMAIN_SUFFIX = "ac.kr";
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void sendVerificationCode(EmailSendRequestDTO request) {
+        String email = request.getEmail();
+        validateUniversityEmail(email);
+        String code = generateCode();
+
+        redisTemplate.opsForValue().set(
+                EMAIL_CODE_PREFIX + email,
+                code,
+                CODE_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+
+        sendEmail(email, code);
+    }
+
+    @Override
+    public void verifyCode(EmailVerifyRequestDTO request) {
+        String email = request.getEmail();
+        String storedCode = redisTemplate.opsForValue().get(EMAIL_CODE_PREFIX + email);
+
+        if (storedCode == null || !storedCode.equals(request.getCode())) {
+            throw new CustomException(UserErrorCode.EMAIL_CODE_INVALID);
+        }
+
+        redisTemplate.delete(EMAIL_CODE_PREFIX + email);
+        redisTemplate.opsForValue().set(
+                EMAIL_VERIFIED_PREFIX + email,
+                "true",
+                VERIFIED_TTL_MINUTES,
+                TimeUnit.MINUTES
+        );
+    }
+
+    @Async
+    protected void sendEmail(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[PickIt] 이메일 인증 코드");
+        message.setText(
+                "안녕하세요, PickIt입니다.\n\n" +
+                "인증 코드: " + code + "\n\n" +
+                "유효 시간은 5분입니다.\n" +
+                "본인이 요청하지 않은 경우 이 메일을 무시해주세요."
+        );
+        mailSender.send(message);
+    }
+
+    private void validateUniversityEmail(String email) {
+        String domain = email.substring(email.indexOf('@') + 1);
+        if (!domain.endsWith(UNIVERSITY_DOMAIN_SUFFIX)) {
+            throw new CustomException(UserErrorCode.EMAIL_DOMAIN_INVALID);
+        }
+    }
+
+    private String generateCode() {
+        return String.format("%06d", new SecureRandom().nextInt(1_000_000));
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
@@ -2,53 +2,8 @@ package com.capstone.pickIt.api.user.service;
 
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
-import com.capstone.pickIt.domain.user.entity.User;
-import com.capstone.pickIt.domain.user.exception.UserErrorCode;
-import com.capstone.pickIt.domain.user.repository.UserRepository;
-import com.capstone.pickIt.global.apiPayload.exception.CustomException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class UserService {
+public interface UserService {
 
-    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
-
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final RedisTemplate<String, String> redisTemplate;
-
-    @Transactional
-    public UserResponseDTO signUp(UserRequestDTO request) { //회원가입 로직
-        String email = request.getEmail();
-
-        if (!Boolean.TRUE.equals(redisTemplate.hasKey(EMAIL_VERIFIED_PREFIX + email))) {
-            throw new CustomException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
-        }
-
-        if (userRepository.existsByEmail(email)) {
-            throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS);
-        }
-
-        User user = User.builder()
-                .email(email)
-                .password(passwordEncoder.encode(request.getPassword()))
-                .nickname(request.getNickname())
-                .major(request.getMajor())
-                .build();
-
-        User savedUser = userRepository.save(user);
-
-        redisTemplate.delete(EMAIL_VERIFIED_PREFIX + email);
-
-        return UserResponseDTO.builder()
-                .userId(savedUser.getUserId())
-                .email(savedUser.getEmail())
-                .nickname(savedUser.getNickname())
-                .build();
-    }
+    UserResponseDTO signUp(UserRequestDTO request);
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
@@ -1,0 +1,54 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public UserResponseDTO signUp(UserRequestDTO request) { //회원가입 로직
+        String email = request.getEmail();
+
+        if (!Boolean.TRUE.equals(redisTemplate.hasKey(EMAIL_VERIFIED_PREFIX + email))) {
+            throw new CustomException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(request.getPassword()))
+                .nickname(request.getNickname())
+                .major(request.getMajor())
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        redisTemplate.delete(EMAIL_VERIFIED_PREFIX + email);
+
+        return UserResponseDTO.builder()
+                .userId(savedUser.getUserId())
+                .email(savedUser.getEmail())
+                .nickname(savedUser.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -1,0 +1,54 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    @Transactional
+    public UserResponseDTO signUp(UserRequestDTO request) {
+        String email = request.getEmail();
+
+        if (!Boolean.TRUE.equals(redisTemplate.hasKey(EMAIL_VERIFIED_PREFIX + email))) {
+            throw new CustomException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS);
+        }
+
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(request.getPassword()))
+                .nickname(request.getNickname())
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        redisTemplate.delete(EMAIL_VERIFIED_PREFIX + email);
+
+        return UserResponseDTO.builder()
+                .userId(savedUser.getUserId())
+                .email(savedUser.getEmail())
+                .nickname(savedUser.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -4,8 +4,8 @@ import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
-import com.capstone.pickIt.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -28,11 +28,11 @@ public class UserServiceImpl implements UserService {
         String email = request.getEmail();
 
         if (!Boolean.TRUE.equals(redisTemplate.hasKey(EMAIL_VERIFIED_PREFIX + email))) {
-            throw new CustomException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+            throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
         }
 
         if (userRepository.existsByEmail(email)) {
-            throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS);
+            throw new UserException(UserErrorCode.USER_ALREADY_EXISTS);
         }
 
         User user = User.builder()

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -26,6 +26,6 @@ public class User extends BaseEntity {
     @Column(name = "nickname", length = 50, nullable = false)
     private String nickname;
 
-    @Column(name = "major", length = 100, nullable = false)
+    @Column(name = "major", length = 100)
     private String major;
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -1,0 +1,38 @@
+package com.capstone.pickIt.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 50, nullable = false)
+    private String nickname;
+
+    @Column(name = "major", length = 100, nullable = false)
+    private String major;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -1,24 +1,23 @@
 package com.capstone.pickIt.domain.user.entity;
 
+import com.capstone.pickIt.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(name = "users")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Column(name = "password", nullable = false)
@@ -29,10 +28,4 @@ public class User {
 
     @Column(name = "major", length = 100, nullable = false)
     private String major;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements BaseCode {
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER409", "이미 존재하는 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER401", "비밀번호가 올바르지 않습니다."),
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
+    EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,21 @@
+package com.capstone.pickIt.domain.user.exception;
+
+import com.capstone.pickIt.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER409", "이미 존재하는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER401", "비밀번호가 올바르지 않습니다."),
+    USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -14,6 +14,7 @@ public enum UserErrorCode implements BaseCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER401", "비밀번호가 올바르지 않습니다."),
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
+    EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),
     UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements BaseCode {
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER4004", "유효하지 않거나 만료된 토큰입니다."),
     UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserException.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.capstone.pickIt.domain.user.exception;
+
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+
+public class UserException extends CustomException {
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    java.util.Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.capstone.pickIt.domain.user.repository;
+
+import com.capstone.pickIt.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/capstone/pickIt/global/apiPayload/exception/CustomException.java
+++ b/src/main/java/com/capstone/pickIt/global/apiPayload/exception/CustomException.java
@@ -20,6 +20,7 @@ public class CustomException extends RuntimeException {
 
     public CustomException(BaseCode errorCode, String message, Throwable cause) {
         super(message, cause);
+
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/capstone/pickIt/global/config/RedisConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.capstone.pickIt.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/capstone/pickIt/global/config/SwaggerConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/SwaggerConfig.java
@@ -14,7 +14,7 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI swagger() {
-        Info info = new Info().title("Finly API 명세서").description("Finly의 SpringBoot 서버 API 명세서입니다.").version("0.0.1");
+        Info info = new Info().title("PickIt API 명세서").description("PickIt의 SpringBoot 서버 API 명세서입니다.").version("0.0.1");
 
         // JWT 토큰 헤더 방식
         String securityScheme = "JWT TOKEN";

--- a/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.capstone.pickIt.global.config.security;
+
+import com.capstone.pickIt.global.infra.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/users/signup",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/actuator/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 "/api/users/signup",
                                 "/api/users/email/send",
                                 "/api/users/email/verify",
+                                "/api/users/login",
+                                "/api/users/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/**"

--- a/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/users/signup",
+                                "/api/users/email/send",
+                                "/api/users/email/verify",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/**"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,19 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application:
     name: pickIt
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #4 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
  
이메일/비밀번호 로그인 및 JWT 토큰 발급

  - 이메일로 사용자 조회, BCrypt 비밀번호 검증 후 Access Token(1시간) + Refresh Token(24시간) 발급. Refresh Token은 Redis에 저장 (refresh:token:{userId})
  - Refresh Token 유효성 및 Redis 저장 값과 일치 여부 검증 후 토큰 재발급. Refresh Token Rotation 적용


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="871" height="567" alt="image" src="https://github.com/user-attachments/assets/1b2c71e9-3143-4142-966e-2c5fc85f338e" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.