### PR TITLE
[Feat] 로그인 및 토큰 재발급 

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -16,8 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,57 +33,51 @@ public class UserController {
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
     @PostMapping("/email/send")
-    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
+    public ApiResponse<Void> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
     @PostMapping("/email/verify")
-    public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
+    public ApiResponse<Void> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
+    public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.<UserResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.CREATED.getCode())
-                        .message("회원가입에 성공했습니다.")
-                        .result(response)
-                        .build());
+        return ApiResponse.<UserResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.CREATED.getCode())
+                .message("회원가입에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO request) {
         LoginResponseDTO response = authService.login(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("로그인에 성공했습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("로그인에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
         LoginResponseDTO response = authService.refresh(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("토큰이 재발급되었습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("토큰이 재발급되었습니다.")
+                .result(response)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -2,8 +2,12 @@ package com.capstone.pickIt.api.user.controller;
 
 import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.api.user.service.AuthService;
 import com.capstone.pickIt.api.user.service.EmailService;
 import com.capstone.pickIt.api.user.service.UserService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
@@ -19,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @Tag(name = "User", description = "유저 API")
 @RestController
 @RequestMapping("/api/users")
@@ -28,23 +31,24 @@ public class UserController {
 
     private final UserService userService;
     private final EmailService emailService;
+    private final AuthService authService;
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
-    @PostMapping("/email/send") //이메일 인증 코드 전송
+    @PostMapping("/email/send")
     public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
-    @PostMapping("/email/verify") // 사용자 이메일 인증 코드 확인
+    @PostMapping("/email/verify")
     public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
-    @PostMapping("/signup") // 회원가입
+    @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
         return ResponseEntity
@@ -55,5 +59,33 @@ public class UserController {
                         .message("회원가입에 성공했습니다.")
                         .result(response)
                         .build());
+    }
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+        LoginResponseDTO response = authService.login(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("로그인에 성공했습니다.")
+                        .result(response)
+                        .build()
+        );
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+        LoginResponseDTO response = authService.refresh(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("토큰이 재발급되었습니다.")
+                        .result(response)
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
@@ -1,0 +1,18 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
@@ -1,0 +1,13 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequestDTO {
+
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -10,6 +10,5 @@ public class LoginResponseDTO {
     private String accessToken;
     private String refreshToken;
     private Long userId;
-    private String email;
     private String nickname;
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -1,0 +1,15 @@
+package com.capstone.pickIt.api.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDTO {
+
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+
+public interface AuthService {
+
+    LoginResponseDTO login(LoginRequestDTO request);
+
+    LoginResponseDTO refresh(TokenRefreshRequestDTO request);
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -65,7 +65,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }
@@ -113,7 +112,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -1,0 +1,120 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.infra.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:token:";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh-token-expire-ms}")
+    private long refreshTokenExpireMs;
+
+
+    /**
+     * 사용자 로그인을 처리합니다.
+     * 1. 사용자 존재 여부 및 비밀번호 검증
+     * 2. Access/Refresh 토큰 생성
+     * 3. Refresh 토큰을 Redis에 저장 (추후 갱신 및 로그아웃용)
+     */
+    @Override
+    public LoginResponseDTO login(LoginRequestDTO request) {
+
+        //이메일로 사용자 조회하기
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        }
+
+        //jwt 토큰 발급
+        String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
+
+        // refresh 토큰을 레디스에 저장
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                refreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    /**
+     * Access 토큰 만료 시 Refresh 토큰을 통해 새로운 토큰 쌍을 발급합니다.
+     * Refresh Token Rotation 전략을 사용하여 보안을 강화합니다.
+     */
+    @Override
+    public LoginResponseDTO refresh(TokenRefreshRequestDTO request) {
+        String refreshToken = request.getRefreshToken();
+
+        //전달 받은 refresh 토큰의 유효성 검증하기
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        // 토큰에서 유저 정보 추출하기
+        Long userId = jwtProvider.getMemberId(refreshToken);
+        String email = jwtProvider.getEmail(refreshToken);
+
+        //레디스에 저장된 토큰하고 일치하는지 확인하기
+        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+        if (!refreshToken.equals(storedToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        //유저 존재 여부 재확인하기
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        //새로운 토큰 쌍 생성하기 기존 토큰은 무효화하고 새롭게 발급해주는 것
+        String newAccessToken = jwtProvider.createAccessToken(userId, email);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId, email);
+
+        //레디스에 새로운 refresh토큰 갱신하기
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + userId,
+                newRefreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements BaseCode {
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER4004", "유효하지 않거나 만료된 토큰입니다."),
     UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    java.util.Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 "/api/users/signup",
                                 "/api/users/email/send",
                                 "/api/users/email/verify",
+                                "/api/users/login",
+                                "/api/users/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/**"


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #4 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
  
이메일/비밀번호 로그인 및 JWT 토큰 발급

  - 이메일로 사용자 조회, BCrypt 비밀번호 검증 후 Access Token(1시간) + Refresh Token(24시간) 발급. Refresh Token은 Redis에 저장 (refresh:token:{userId})
  - Refresh Token 유효성 및 Redis 저장 값과 일치 여부 검증 후 토큰 재발급. Refresh Token Rotation 적용


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="871" height="567" alt="image" src="https://github.com/user-attachments/assets/1b2c71e9-3143-4142-966e-2c5fc85f338e" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 기능 추가 - 이메일과 비밀번호를 통한 사용자 인증 및 접근 토큰 발급
  * 토큰 갱신 기능 추가 - 갱신 토큰을 사용하여 새로운 접근 토큰 재발급 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->