### PR TITLE
 [Feat] 로그인 및 토큰 재발급

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -16,8 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,57 +33,51 @@ public class UserController {
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
     @PostMapping("/email/send")
-    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
+    public ApiResponse<Void> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
     @PostMapping("/email/verify")
-    public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
+    public ApiResponse<Void> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
+        return ApiResponse.onSuccess(null, SuccessCode.OK);
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
+    public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.<UserResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.CREATED.getCode())
-                        .message("회원가입에 성공했습니다.")
-                        .result(response)
-                        .build());
+        return ApiResponse.<UserResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.CREATED.getCode())
+                .message("회원가입에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO request) {
         LoginResponseDTO response = authService.login(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("로그인에 성공했습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("로그인에 성공했습니다.")
+                .result(response)
+                .build();
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+    public ApiResponse<LoginResponseDTO> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
         LoginResponseDTO response = authService.refresh(request);
-        return ResponseEntity.ok(
-                ApiResponse.<LoginResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.OK.getCode())
-                        .message("토큰이 재발급되었습니다.")
-                        .result(response)
-                        .build()
-        );
+        return ApiResponse.<LoginResponseDTO>builder()
+                .isSuccess(true)
+                .code(SuccessCode.OK.getCode())
+                .message("토큰이 재발급되었습니다.")
+                .result(response)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,14 +49,15 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
+    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
-        return ApiResponse.<UserResponseDTO>builder()
-                .isSuccess(true)
-                .code(SuccessCode.CREATED.getCode())
-                .message("회원가입에 성공했습니다.")
-                .result(response)
-                .build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.<UserResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.CREATED.getCode())
+                        .message("회원가입에 성공했습니다.")
+                        .result(response)
+                        .build());
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -2,8 +2,12 @@ package com.capstone.pickIt.api.user.controller;
 
 import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.api.user.service.AuthService;
 import com.capstone.pickIt.api.user.service.EmailService;
 import com.capstone.pickIt.api.user.service.UserService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
@@ -19,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @Tag(name = "User", description = "유저 API")
 @RestController
 @RequestMapping("/api/users")
@@ -28,23 +31,24 @@ public class UserController {
 
     private final UserService userService;
     private final EmailService emailService;
+    private final AuthService authService;
 
     @Operation(summary = "이메일 인증코드 전송", description = "대학교 이메일로 인증코드를 전송합니다.")
-    @PostMapping("/email/send") //이메일 인증 코드 전송
+    @PostMapping("/email/send")
     public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
-    @PostMapping("/email/verify") // 사용자 이메일 인증 코드 확인
+    @PostMapping("/email/verify")
     public ResponseEntity<ApiResponse<Void>> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
         return ResponseEntity.ok(ApiResponse.onSuccess(null, SuccessCode.OK));
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
-    @PostMapping("/signup") // 회원가입
+    @PostMapping("/signup")
     public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
         return ResponseEntity
@@ -55,5 +59,33 @@ public class UserController {
                         .message("회원가입에 성공했습니다.")
                         .result(response)
                         .build());
+    }
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request) {
+        LoginResponseDTO response = authService.login(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("로그인에 성공했습니다.")
+                        .result(response)
+                        .build()
+        );
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
+        LoginResponseDTO response = authService.refresh(request);
+        return ResponseEntity.ok(
+                ApiResponse.<LoginResponseDTO>builder()
+                        .isSuccess(true)
+                        .code(SuccessCode.OK.getCode())
+                        .message("토큰이 재발급되었습니다.")
+                        .result(response)
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/LoginRequestDTO.java
@@ -1,0 +1,18 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/TokenRefreshRequestDTO.java
@@ -1,0 +1,13 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRefreshRequestDTO {
+
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -10,6 +10,5 @@ public class LoginResponseDTO {
     private String accessToken;
     private String refreshToken;
     private Long userId;
-    private String email;
     private String nickname;
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/LoginResponseDTO.java
@@ -1,0 +1,15 @@
+package com.capstone.pickIt.api.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDTO {
+
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthService.java
@@ -1,0 +1,12 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+
+public interface AuthService {
+
+    LoginResponseDTO login(LoginRequestDTO request);
+
+    LoginResponseDTO refresh(TokenRefreshRequestDTO request);
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -65,7 +65,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }
@@ -113,7 +112,6 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .userId(user.getUserId())
-                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .build();
     }

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -47,11 +47,9 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public LoginResponseDTO login(LoginRequestDTO request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        User user = userRepository.findByEmail(request.getEmail()).orElse(null);
+        if (user == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.AUTHENTICATION_FAILED);
         }
 
         String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -11,9 +11,11 @@ import com.capstone.pickIt.global.infra.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -21,6 +23,19 @@ import java.util.concurrent.TimeUnit;
 public class AuthServiceImpl implements AuthService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refresh:token:";
+
+    // Refresh Token Rotation을 원자적으로 처리하는 Lua 스크립트
+    // 기존 토큰과 일치할 때만 새 토큰으로 교체 (Race Condition 방지)
+    private static final DefaultRedisScript<Long> REFRESH_TOKEN_ROTATION_SCRIPT =
+            new DefaultRedisScript<>(
+                    "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+                    "   redis.call('set', KEYS[1], ARGV[2], 'PX', ARGV[3]) " +
+                    "   return 1 " +
+                    "else " +
+                    "   return 0 " +
+                    "end",
+                    Long.class
+            );
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -30,30 +45,18 @@ public class AuthServiceImpl implements AuthService {
     @Value("${jwt.refresh-token-expire-ms}")
     private long refreshTokenExpireMs;
 
-
-    /**
-     * 사용자 로그인을 처리합니다.
-     * 1. 사용자 존재 여부 및 비밀번호 검증
-     * 2. Access/Refresh 토큰 생성
-     * 3. Refresh 토큰을 Redis에 저장 (추후 갱신 및 로그아웃용)
-     */
     @Override
     public LoginResponseDTO login(LoginRequestDTO request) {
-
-        //이메일로 사용자 조회하기
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        // 비밀번호 일치 여부 확인
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }
 
-        //jwt 토큰 발급
         String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
 
-        // refresh 토큰을 레디스에 저장
         redisTemplate.opsForValue().set(
                 REFRESH_TOKEN_PREFIX + user.getUserId(),
                 refreshToken,
@@ -69,44 +72,36 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
-    /**
-     * Access 토큰 만료 시 Refresh 토큰을 통해 새로운 토큰 쌍을 발급합니다.
-     * Refresh Token Rotation 전략을 사용하여 보안을 강화합니다.
-     */
     @Override
     public LoginResponseDTO refresh(TokenRefreshRequestDTO request) {
-        String refreshToken = request.getRefreshToken();
+        //  Bearer 접두사 제거 후 정규화된 토큰으로 이후 모든 작업 수행
+        String refreshToken = jwtProvider.normalize(request.getRefreshToken());
 
-        //전달 받은 refresh 토큰의 유효성 검증하기
         if (!jwtProvider.validateRefreshToken(refreshToken)) {
             throw new UserException(UserErrorCode.TOKEN_INVALID);
         }
 
-        // 토큰에서 유저 정보 추출하기
         Long userId = jwtProvider.getMemberId(refreshToken);
-        String email = jwtProvider.getEmail(refreshToken);
 
-        //레디스에 저장된 토큰하고 일치하는지 확인하기
-        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
-        if (!refreshToken.equals(storedToken)) {
-            throw new UserException(UserErrorCode.TOKEN_INVALID);
-        }
-
-        //유저 존재 여부 재확인하기
-        User user = userRepository.findByEmail(email)
+        // 변경 불가능한 userId로 사용자 조회 → 최신 이메일로 새 토큰 생성
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        //새로운 토큰 쌍 생성하기 기존 토큰은 무효화하고 새롭게 발급해주는 것
-        String newAccessToken = jwtProvider.createAccessToken(userId, email);
-        String newRefreshToken = jwtProvider.createRefreshToken(userId, email);
+        String newAccessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
+        String newRefreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
 
-        //레디스에 새로운 refresh토큰 갱신하기
-        redisTemplate.opsForValue().set(
-                REFRESH_TOKEN_PREFIX + userId,
+        // Lua 스크립트로 기존 토큰 검증 + 새 토큰 저장을 원자적으로 처리
+        Long result = redisTemplate.execute(
+                REFRESH_TOKEN_ROTATION_SCRIPT,
+                Collections.singletonList(REFRESH_TOKEN_PREFIX + userId),
+                refreshToken,
                 newRefreshToken,
-                refreshTokenExpireMs,
-                TimeUnit.MILLISECONDS
+                String.valueOf(refreshTokenExpireMs)
         );
+
+        if (result == null || result == 0L) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
 
         return LoginResponseDTO.builder()
                 .accessToken(newAccessToken)

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -1,0 +1,120 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
+import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.infra.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:token:";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh-token-expire-ms}")
+    private long refreshTokenExpireMs;
+
+
+    /**
+     * 사용자 로그인을 처리합니다.
+     * 1. 사용자 존재 여부 및 비밀번호 검증
+     * 2. Access/Refresh 토큰 생성
+     * 3. Refresh 토큰을 Redis에 저장 (추후 갱신 및 로그아웃용)
+     */
+    @Override
+    public LoginResponseDTO login(LoginRequestDTO request) {
+
+        //이메일로 사용자 조회하기
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        }
+
+        //jwt 토큰 발급
+        String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
+
+        // refresh 토큰을 레디스에 저장
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + user.getUserId(),
+                refreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    /**
+     * Access 토큰 만료 시 Refresh 토큰을 통해 새로운 토큰 쌍을 발급합니다.
+     * Refresh Token Rotation 전략을 사용하여 보안을 강화합니다.
+     */
+    @Override
+    public LoginResponseDTO refresh(TokenRefreshRequestDTO request) {
+        String refreshToken = request.getRefreshToken();
+
+        //전달 받은 refresh 토큰의 유효성 검증하기
+        if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        // 토큰에서 유저 정보 추출하기
+        Long userId = jwtProvider.getMemberId(refreshToken);
+        String email = jwtProvider.getEmail(refreshToken);
+
+        //레디스에 저장된 토큰하고 일치하는지 확인하기
+        String storedToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId);
+        if (!refreshToken.equals(storedToken)) {
+            throw new UserException(UserErrorCode.TOKEN_INVALID);
+        }
+
+        //유저 존재 여부 재확인하기
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        //새로운 토큰 쌍 생성하기 기존 토큰은 무효화하고 새롭게 발급해주는 것
+        String newAccessToken = jwtProvider.createAccessToken(userId, email);
+        String newRefreshToken = jwtProvider.createRefreshToken(userId, email);
+
+        //레디스에 새로운 refresh토큰 갱신하기
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_PREFIX + userId,
+                newRefreshToken,
+                refreshTokenExpireMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return LoginResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements BaseCode {
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER4004", "유효하지 않거나 만료된 토큰입니다."),
     UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -12,6 +12,7 @@ public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER409", "이미 존재하는 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "USER401", "비밀번호가 올바르지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "USER4010", "이메일 또는 비밀번호가 올바르지 않습니다."),
     USER_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4001", "이메일 인증이 완료되지 않은 사용자입니다."),
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),

--- a/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
+
+    java.util.Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 "/api/users/signup",
                                 "/api/users/email/send",
                                 "/api/users/email/verify",
+                                "/api/users/login",
+                                "/api/users/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/actuator/**"


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #4 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
  
이메일/비밀번호 로그인 및 JWT 토큰 발급

  - 이메일로 사용자 조회, BCrypt 비밀번호 검증 후 Access Token(1시간) + Refresh Token(24시간) 발급. Refresh Token은 Redis에 저장 (refresh:token:{userId})
  - Refresh Token 유효성 및 Redis 저장 값과 일치 여부 검증 후 토큰 재발급. Refresh Token Rotation 적용


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="871" height="567" alt="image" src="https://github.com/user-attachments/assets/1b2c71e9-3143-4142-966e-2c5fc85f338e" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일/비밀번호 기반 로그인 및 토큰 새로고침(재발급) 엔드포인트 추가

* **개선**
  * 로그인/리프레시에서 액세스·리프레시 토큰 발급 및 회전 로직 강화
  * API 응답 형식 간소화 및 일관성 개선
  * 로그인·리프레시 엔드포인트의 인증 예외 규칙 명확화

* **버그 수정 / 오류 처리**
  * 인증 실패 및 유효하지 않은 토큰에 대한 명확한 오류 코드/응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->