### PR TITLE
[Chore] 기존 엔티티 코드들을 BaseEntity 상속받도록 수정

### DIFF
--- a/src/main/java/com/capstone/pickIt/domain/course/entity/Course.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/entity/Course.java
@@ -1,9 +1,8 @@
 package com.capstone.pickIt.domain.course.entity;
 
+import com.capstone.pickIt.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "course")
@@ -11,7 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Course {
+public class Course extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,22 +22,4 @@ public class Course {
 
     @Column(name = "semester", nullable = false, length = 20)
     private String semester;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/capstone/pickIt/domain/course/entity/UserCourseProfile.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/entity/UserCourseProfile.java
@@ -1,10 +1,9 @@
 package com.capstone.pickIt.domain.course.entity;
 
 import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedUpdatedDeletedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(
@@ -20,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserCourseProfile {
+public class UserCourseProfile extends CreatedUpdatedDeletedBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,18 +42,6 @@ public class UserCourseProfile {
     @Column(name = "recruitment_status", nullable = false, length = 30)
     private RecruitmentStatus recruitmentStatus;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     public void changeRecruitmentStatus(RecruitmentStatus recruitmentStatus) {
         if (recruitmentStatus == null) {
             throw new IllegalArgumentException("모집 상태는 필수입니다.");
@@ -63,17 +50,8 @@ public class UserCourseProfile {
         this.recruitmentStatus = recruitmentStatus;
     }
 
-    public void delete() {
-        this.deleted = true;
-        this.deletedAt = LocalDateTime.now();
-    }
-
     @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-
+    protected void onCreateUserCourseProfile() {
         if (this.importanceLevel == null) {
             this.importanceLevel = ImportanceLevel.HIGH;
         }
@@ -81,10 +59,5 @@ public class UserCourseProfile {
         if (this.recruitmentStatus == null) {
             this.recruitmentStatus = RecruitmentStatus.RECRUITING;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/course/entity/UserCourseTrait.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/entity/UserCourseTrait.java
@@ -1,5 +1,6 @@
 package com.capstone.pickIt.domain.course.entity;
 
+import com.capstone.pickIt.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,7 +20,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserCourseTrait {
+public class UserCourseTrait extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,22 +38,4 @@ public class UserCourseTrait {
     @Enumerated(EnumType.STRING)
     @Column(name = "selected_side", nullable = false, length = 1)
     private TraitSide selectedSide;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/capstone/pickIt/domain/point/entity/PointTransaction.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/entity/PointTransaction.java
@@ -2,6 +2,7 @@ package com.capstone.pickIt.domain.point.entity;
 
 import com.capstone.pickIt.domain.project.entity.ProjectTeam;
 import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class PointTransaction {
+public class PointTransaction extends CreatedBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,14 +41,4 @@ public class PointTransaction {
 
     @Column(name = "description", length = 255)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
-        }
-    }
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ChecklistItem.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ChecklistItem.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.entity;
 
 import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedUpdatedDeletedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ChecklistItem {
+public class ChecklistItem extends CreatedUpdatedDeletedBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,18 +50,6 @@ public class ChecklistItem {
     @JoinColumn(name = "created_by_user_id", nullable = false)
     private User createdByUser;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
     public void update(String title, LocalDate dueDate, User manager) {
         if (title == null || manager == null) {
             throw new IllegalArgumentException("제목과 담당자는 필수입니다.");
@@ -83,24 +72,10 @@ public class ChecklistItem {
         this.completedAt = null;
     }
 
-    public void delete() {
-        this.deleted = true;
-        this.deletedAt = LocalDateTime.now();
-    }
-
     @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-
+    protected void onCreateChecklistItem() {
         if (this.status == null) {
             this.status = ChecklistStatus.TODO;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/PeerReview.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/PeerReview.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.entity;
 
 import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,7 +23,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class PeerReview {
+public class PeerReview extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,20 +57,12 @@ public class PeerReview {
     @Column(name = "submitted_at")
     private LocalDateTime submittedAt;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     @PrePersist
-    protected void onCreate() {
+    protected void onCreatePeerReview() {
         validateScores();
         calculateAverageScore();
 
         LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
 
         if (this.submittedAt == null) {
             this.submittedAt = now;
@@ -80,7 +73,6 @@ public class PeerReview {
     protected void onUpdate() {
         validateScores();
         calculateAverageScore();
-        this.updatedAt = LocalDateTime.now();
     }
 
     private void validateScores() {

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.entity;
 
 import com.capstone.pickIt.domain.course.entity.Course;
+import com.capstone.pickIt.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ProjectTeam {
+public class ProjectTeam extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,12 +38,6 @@ public class ProjectTeam {
     @Column(name = "ended_at")
     private LocalDateTime endedAt;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     public void start() {
         if (this.status != ProjectTeamStatus.RECRUITING) {
             throw new IllegalStateException("Project team은 RECRUITING 상태에서만 시작 가능합니다.");
@@ -63,18 +58,9 @@ public class ProjectTeam {
     }
 
     @PrePersist
-    protected void onCreate() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-
+    protected void onCreateProjectTeam() {
         if (this.status == null) {
             this.status = ProjectTeamStatus.RECRUITING;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeamMember.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeamMember.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.entity;
 
 import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,7 +21,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ProjectTeamMember {
+public class ProjectTeamMember extends CreatedBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,9 +48,6 @@ public class ProjectTeamMember {
 
     @Column(name = "review_completed_at")
     private LocalDateTime reviewCompletedAt;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "recruitment_confirm_status", nullable = false, length = 20)
@@ -96,7 +94,6 @@ public class ProjectTeamMember {
     @PrePersist
     protected void onCreate() {
         LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
 
         if (this.joinedAt == null) {
             this.joinedAt = now;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #17

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

기존 엔티티 코드들은 createdAt, updatedAt 등을 명시적으로 사용하고 있었는데, 적절한 BaseEntity를 상속받도록 수정했습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

X


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 기본 엔티티 클래스를 활용하여 생성·수정·삭제 시간 추적 기능을 표준화했습니다. 이를 통해 여러 엔티티의 코드 일관성과 유지보수성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->