### PR TITLE
[Chore] ApiResponse 및 UserController 일부 수정

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "유저 API")
@@ -44,6 +45,7 @@ public class UserController {
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/signup")
     public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);

--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -17,12 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "유저 API")
 @RestController
@@ -38,65 +33,44 @@ public class UserController {
     @PostMapping("/email/send")
     public ApiResponse<Void> sendVerificationCode(@RequestBody @Valid EmailSendRequestDTO request) {
         emailService.sendVerificationCode(request);
-        return ApiResponse.onSuccess(null, SuccessCode.OK);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
     }
 
     @Operation(summary = "이메일 인증코드 확인", description = "전송된 인증코드를 검증합니다.")
     @PostMapping("/email/verify")
     public ApiResponse<Void> verifyCode(@RequestBody @Valid EmailVerifyRequestDTO request) {
         emailService.verifyCode(request);
-        return ApiResponse.onSuccess(null, SuccessCode.OK);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
     }
 
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponseDTO>> signUp(@RequestBody @Valid UserRequestDTO request) {
+    public ApiResponse<UserResponseDTO> signUp(@RequestBody @Valid UserRequestDTO request) {
         UserResponseDTO response = userService.signUp(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.<UserResponseDTO>builder()
-                        .isSuccess(true)
-                        .code(SuccessCode.CREATED.getCode())
-                        .message("회원가입에 성공했습니다.")
-                        .result(response)
-                        .build());
+        return ApiResponse.onSuccess(SuccessCode.CREATED, response);
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
     public ApiResponse<LoginResponseDTO> login(@RequestBody @Valid LoginRequestDTO request) {
         LoginResponseDTO response = authService.login(request);
-        return ApiResponse.<LoginResponseDTO>builder()
-                .isSuccess(true)
-                .code(SuccessCode.OK.getCode())
-                .message("로그인에 성공했습니다.")
-                .result(response)
-                .build();
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token을 재발급합니다.")
     @PostMapping("/refresh")
     public ApiResponse<LoginResponseDTO> refresh(@RequestBody @Valid TokenRefreshRequestDTO request) {
         LoginResponseDTO response = authService.refresh(request);
-        return ApiResponse.<LoginResponseDTO>builder()
-                .isSuccess(true)
-                .code(SuccessCode.OK.getCode())
-                .message("토큰이 재발급되었습니다.")
-                .result(response)
-                .build();
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
     }
 
     @Operation(
             summary = "로그아웃",
-            description = "Access Token을 무효화하고 Refresh Token을 삭제합니다.\n\n"
+            description = "Access Token을 무효화하고 Refresh Token을 삭제합니다."
     )
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request) {
         authService.logout(request.getHeader("Authorization"));
-        return ApiResponse.<Void>builder()
-                .isSuccess(true)
-                .code(SuccessCode.OK.getCode())
-                .message("로그아웃에 성공했습니다.")
-                .result(null)
-                .build();
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
     }
 }

--- a/src/main/java/com/capstone/pickIt/global/apiPayload/response/ApiResponse.java
+++ b/src/main/java/com/capstone/pickIt/global/apiPayload/response/ApiResponse.java
@@ -22,7 +22,7 @@ public class ApiResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T result;
 
-    public static <T> ApiResponse<T> onSuccess(T result, BaseCode code) {
+    public static <T> ApiResponse<T> onSuccess(BaseCode code, T result) {
         return ApiResponse.<T>builder()
                 .isSuccess(true)
                 .code(code.getCode())


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

X

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 기존 onSuccess() 코드와 onFailure() 코드의 인자 순서가 상이하여 헷갈릴까 둘의 인자 순서를 통일하였습니다.
- 인자 순서 변경에 따라 UserController에 구현된 코드의 인자 순서를 변경했습니다.
- 또한, ResponseEntity와 build() 등을 혼용하고 있던 코드를 SuccessCode를 활용하도록 수정했습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 모든 인증 및 사용자 관련 엔드포인트의 응답 형식을 표준화하여 일관된 성공 응답 제공
  * 내부 응답 처리 로직 간소화로 유지보수성 및 일관성 향상

* **버그 수정**
  * 문서화/설명 텍스트의 불필요한 개행 제거로 설명 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->