### PR TITLE
[Feat] 온보딩 기본 팀플 성향 입력 및 저장 

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.capstone.pickIt.api.user.dto.request.EmailSendRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.EmailVerifyRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.LoginRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.OnboardingBasicInfoRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.OnboardingPersonalityRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.TokenRefreshRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.LoginResponseDTO;
@@ -94,5 +95,20 @@ public class UserController {
         Long userId = SecurityUtil.requireUserId();
         onboardingService.saveBasicInfo(userId, request);
         return ApiResponse.onSuccess(SuccessCode.OK, "기본 정보가 저장되었습니다.");
+    }
+
+    @Operation(
+            summary = "온보딩 팀플 성향 저장",
+            description = "팀플 성향 선택값을 저장합니다.\n\n" +
+                    "- 4개 스탭의 선택을 모두 완료한 후 **한 번에** 전송해야 합니다.\n" +
+                    "- 스탭마다 개별 호출 시 이전 선택이 삭제됩니다.\n" +
+                    "- `traitItemId`: GET /api/traits 로 조회한 성향 항목 ID\n" +
+                    "- `selectedType`: nameA 선택 → A, nameB 선택 → B"
+    )
+    @PostMapping("/onboarding/personality")
+    public ApiResponse<String> savePersonality(@RequestBody @Valid OnboardingPersonalityRequestDTO request) {
+        Long userId = SecurityUtil.requireUserId();
+        onboardingService.savePersonality(userId, request);
+        return ApiResponse.onSuccess(SuccessCode.OK, "팀플 성향 입력이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
@@ -1,0 +1,49 @@
+package com.capstone.pickIt.api.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(
+        description = "온보딩 팀플 성향 저장 요청. 모든 스탭 선택 완료 후 한 번에 전송해야 합니다.",
+        example = """
+                {
+                  "traits": [
+                    { "traitItemId": 1, "selectedType": "A" },
+                    { "traitItemId": 2, "selectedType": "B" },
+                    { "traitItemId": 3, "selectedType": "A" },
+                    { "traitItemId": 4, "selectedType": "A" }
+                  ]
+                }
+                """
+)
+public class OnboardingPersonalityRequestDTO {
+
+    @NotEmpty(message = "성향 목록은 비어 있을 수 없습니다.")
+    @Valid
+    @Schema(description = "팀플 성향 선택 목록 (전체 스탭 선택값을 한 번에 담아서 전송)")
+    private List<TraitItem> traits;
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "개별 성향 선택 항목")
+    public static class TraitItem {
+
+        @NotNull(message = "성향 항목 ID는 필수입니다.")
+        @Schema(description = "성향 항목 ID", example = "1")
+        private Long traitItemId;
+
+        @NotNull(message = "선택값은 필수입니다.")
+        @Pattern(regexp = "^(A|B)$", message = "selectedType은 A 또는 B만 가능합니다.")
+        @Schema(description = "선택한 항목 (A 또는 B). nameA 선택 시 A, nameB 선택 시 B", example = "A", allowableValues = {"A", "B"})
+        private String selectedType;
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
@@ -1,11 +1,11 @@
 package com.capstone.pickIt.api.user.dto.request;
 
+import com.capstone.pickIt.domain.trait.entity.TraitSide;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,8 +29,10 @@ import java.util.List;
 )
 public class OnboardingPersonalityRequestDTO {
 
+    private static final int TRAIT_COUNT = 4;
+
     @NotEmpty(message = "성향 목록은 비어 있을 수 없습니다.")
-    @Size(min = 4, max = 4, message = "성향 목록은 4개 항목을 모두 포함해야 합니다.")
+    @Size(min = TRAIT_COUNT, max = TRAIT_COUNT, message = "성향 목록은 4개 항목을 모두 포함해야 합니다.")
     @Valid
     @Schema(description = "팀플 성향 선택 목록 (전체 스탭 선택값을 한 번에 담아서 전송)")
     private List<TraitItem> traits;
@@ -54,8 +56,7 @@ public class OnboardingPersonalityRequestDTO {
         private Long traitItemId;
 
         @NotNull(message = "선택값은 필수입니다.")
-        @Pattern(regexp = "^(A|B)$", message = "selectedType은 A 또는 B만 가능합니다.")
-        @Schema(description = "선택한 항목 (A 또는 B). nameA 선택 시 A, nameB 선택 시 B", example = "A", allowableValues = {"A", "B"})
-        private String selectedType;
+        @Schema(description = "선택한 항목 (A 또는 B). nameA 선택 시 A, nameB 선택 시 B", example = "A")
+        private TraitSide selectedType;
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/OnboardingPersonalityRequestDTO.java
@@ -2,9 +2,11 @@ package com.capstone.pickIt.api.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,9 +30,19 @@ import java.util.List;
 public class OnboardingPersonalityRequestDTO {
 
     @NotEmpty(message = "성향 목록은 비어 있을 수 없습니다.")
+    @Size(min = 4, max = 4, message = "성향 목록은 4개 항목을 모두 포함해야 합니다.")
     @Valid
     @Schema(description = "팀플 성향 선택 목록 (전체 스탭 선택값을 한 번에 담아서 전송)")
     private List<TraitItem> traits;
+
+    @AssertTrue(message = "중복된 traitItemId는 허용되지 않습니다.")
+    private boolean hasUniqueTraitItemIds() {
+        if (traits == null) return true;
+        return traits.stream()
+                .map(TraitItem::getTraitItemId)
+                .distinct()
+                .count() == traits.size();
+    }
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/UserDefaultTraitRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/UserDefaultTraitRequestDTO.java
@@ -3,11 +3,13 @@ package com.capstone.pickIt.api.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserDefaultTraitRequestDTO {
 
     @NotNull(message = "성향 항목 ID는 필수입니다.")

--- a/src/main/java/com/capstone/pickIt/api/user/service/OnboardingService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/OnboardingService.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.api.user.service;
 
 import com.capstone.pickIt.api.user.dto.request.OnboardingBasicInfoRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.OnboardingPersonalityRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.OnboardingStatusResponseDTO;
 
 public interface OnboardingService {
@@ -8,4 +9,6 @@ public interface OnboardingService {
     OnboardingStatusResponseDTO getOnboardingStatus(Long userId);
 
     void saveBasicInfo(Long userId, OnboardingBasicInfoRequestDTO request);
+
+    void savePersonality(Long userId, OnboardingPersonalityRequestDTO request);
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
@@ -72,7 +72,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     @Transactional
     public void savePersonality(Long userId, OnboardingPersonalityRequestDTO request) {
         List<UserDefaultTraitRequestDTO> traits = request.getTraits().stream()
-                .map(item -> new UserDefaultTraitRequestDTO(item.getTraitItemId(), item.getSelectedType()))
+                .map(item -> new UserDefaultTraitRequestDTO(item.getTraitItemId(), item.getSelectedType().name()))
                 .toList();
         userDefaultTraitService.updateDefaultTraits(userId, traits);
     }

--- a/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
@@ -1,6 +1,8 @@
 package com.capstone.pickIt.api.user.service;
 
 import com.capstone.pickIt.api.user.dto.request.OnboardingBasicInfoRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.OnboardingPersonalityRequestDTO;
+import com.capstone.pickIt.api.user.dto.request.UserDefaultTraitRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.OnboardingStatusResponseDTO;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.entity.UserCourse;
@@ -14,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class OnboardingServiceImpl implements OnboardingService {
@@ -21,6 +25,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final UserRepository userRepository;
     private final CourseRepository courseRepository;
     private final UserCourseRepository userCourseRepository;
+    private final UserDefaultTraitService userDefaultTraitService;
 
     @Override
     @Transactional(readOnly = true)
@@ -61,5 +66,14 @@ public class OnboardingServiceImpl implements OnboardingService {
                 );
             }
         }
+    }
+
+    @Override
+    @Transactional
+    public void savePersonality(Long userId, OnboardingPersonalityRequestDTO request) {
+        List<UserDefaultTraitRequestDTO> traits = request.getTraits().stream()
+                .map(item -> new UserDefaultTraitRequestDTO(item.getTraitItemId(), item.getSelectedType()))
+                .toList();
+        userDefaultTraitService.updateDefaultTraits(userId, traits);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #43 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  온보딩 단계에서 사용자의 팀플 성향을 저장하는 API를 구현했습니다.                                                                                                                                                            
  - POST /api/users/onboarding/personality 엔드포인트 추가                                                                                                                                                                  
  - OnboardingPersonalityRequestDTO 생성 (traitItemId, selectedType 필드, A/B 유효성 검증)
  - OnboardingService / OnboardingServiceImpl에 savePersonality 로직 추가
  - 기존 UserDefaultTraitService.updateDefaultTraits 재사용 → 기존 데이터 존재 시 삭제 후 저장 처리


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="867" height="552" alt="스크린샷 2026-05-15 160837" src="https://github.com/user-attachments/assets/6cbe9449-d852-46ec-b602-a8810af7d2bd" />
<img width="917" height="551" alt="스크린샷 2026-05-15 160853" src="https://github.com/user-attachments/assets/e06f9c3b-ae65-43a3-a47a-2a9d67002f49" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 온보딩 프로세스에 팀플레이 성향 선택 기능이 추가되었습니다. 사용자는 이제 여러 성향 항목 중 선택값을 저장할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/53)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->