### PR TITLE
[Refactor] 닉네임 비속어 필터링 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // Bad word filtering
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/request/UserRequestDTO.java
@@ -1,5 +1,6 @@
 package com.capstone.pickIt.api.user.dto.request;
 
+import com.capstone.pickIt.global.validation.annotation.NoBadWords;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -20,5 +21,6 @@ public class UserRequestDTO {
 
     @NotBlank
     @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+    @NoBadWords
     private String nickname;
 }

--- a/src/main/java/com/capstone/pickIt/global/validation/annotation/NoBadWords.java
+++ b/src/main/java/com/capstone/pickIt/global/validation/annotation/NoBadWords.java
@@ -1,0 +1,19 @@
+package com.capstone.pickIt.global.validation.annotation;
+
+import com.capstone.pickIt.global.validation.validator.NoBadWordsValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NoBadWordsValidator.class)
+public @interface NoBadWords {
+    String message() default "닉네임에 비속어를 사용할 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/capstone/pickIt/global/validation/validator/NoBadWordsValidator.java
+++ b/src/main/java/com/capstone/pickIt/global/validation/validator/NoBadWordsValidator.java
@@ -1,0 +1,17 @@
+package com.capstone.pickIt.global.validation.validator;
+
+import com.capstone.pickIt.global.validation.annotation.NoBadWords;
+import com.vane.badwordfiltering.BadWordFiltering;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NoBadWordsValidator implements ConstraintValidator<NoBadWords, String> {
+
+    private final BadWordFiltering badWordFiltering = new BadWordFiltering();
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        return !badWordFiltering.check(value);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #11 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  회원가입 시 닉네임에 비속어가 포함될 경우 가입을 차단하는 필터링 기능을 추가했습니다.                                                                                                                                 
  - build.gradle에 io.github.vaneproject:badwordfiltering:1.0.0 의존성 추가                                                                                                                                          
  - @NoBadWords 커스텀 Bean Validation 어노테이션 생성 (global/validation/annotation)
  - NoBadWordsValidator 구현 — BadWordFiltering.check()로 비속어 감지 (global/validation/validator)
  - UserRequestDTO.nickname 필드에 @NoBadWords 적용


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="876" height="362" alt="image" src="https://github.com/user-attachments/assets/411bb456-fdf4-4082-ab1e-83677361714a" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


  비속어 포함 닉네임 입력 시 기존 validation과 동일한 형태로 400 응답 반환됩니다.

  {
    "isSuccess": false,
    "code": "COMMON400",
    "result": { "nickname": "닉네임에 비속어를 사용할 수 없습니다." }
  }
