### PR TITLE
[Feat] 회원 탈퇴 

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/UserController.java
@@ -89,6 +89,15 @@ public class UserController {
         return ApiResponse.onSuccess(SuccessCode.OK, onboardingService.getOnboardingStatus(userId));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "계정을 비활성화합니다. 탈퇴 후 30일 뒤 계정이 완전히 삭제됩니다.")
+    @DeleteMapping("/delete")
+    public ApiResponse<String> withdraw(HttpServletRequest request) {
+        Long userId = SecurityUtil.requireUserId();
+        userService.withdrawUser(userId);
+        authService.logout(request.getHeader("Authorization"));
+        return ApiResponse.onSuccess(SuccessCode.OK, "회원 탈퇴가 완료되었습니다.");
+    }
+
     @Operation(summary = "온보딩 기본 정보 저장", description = "학교, 학과, 학년, 학기, 수강 강의를 저장합니다.")
     @PostMapping("/onboarding/profile")
     public ApiResponse<String> saveBasicInfo(@RequestBody @Valid OnboardingBasicInfoRequestDTO request) {

--- a/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/AuthServiceImpl.java
@@ -49,7 +49,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public LoginResponseDTO login(LoginRequestDTO request) {
         User user = userRepository.findByEmail(request.getEmail()).orElse(null);
-        if (user == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+        if (user == null || !passwordEncoder.matches(request.getPassword(), user.getPassword()) || user.isWithdrawn()) {
             throw new UserException(UserErrorCode.AUTHENTICATION_FAILED);
         }
 

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserService.java
@@ -6,4 +6,6 @@ import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
 public interface UserService {
 
     UserResponseDTO signUp(UserRequestDTO request);
+
+    void withdrawUser(Long userId);
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -24,6 +24,19 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isWithdrawn()) {
+            throw new UserException(UserErrorCode.ALREADY_WITHDRAWN);
+        }
+
+        user.withdraw();
+    }
+
+    @Override
+    @Transactional
     public UserResponseDTO signUp(UserRequestDTO request) {
         String email = request.getEmail();
 

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -7,16 +7,20 @@ import com.capstone.pickIt.domain.user.exception.UserErrorCode;
 import com.capstone.pickIt.domain.user.exception.UserException;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
     private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
+    static final String WITHDRAWN_USER_PREFIX = "withdrawn:user:";
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -33,6 +37,14 @@ public class UserServiceImpl implements UserService {
         }
 
         user.withdraw();
+
+        try {
+            userRepository.flush();
+        } catch (OptimisticLockingFailureException e) {
+            throw new UserException(UserErrorCode.ALREADY_WITHDRAWN);
+        }
+
+        redisTemplate.opsForValue().set(WITHDRAWN_USER_PREFIX + userId, "1", Duration.ofDays(31));
     }
 
     @Override

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -48,11 +48,22 @@ public class User extends BaseEntity {
     @Column(name = "onboarding_step", nullable = false)
     private int onboardingStep = 1;
 
-    public void updateBasicInfo(String school, String major, Integer grade, String semester) { // 기본 정보 업데이트
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
+
+    public void updateBasicInfo(String school, String major, Integer grade, String semester) {
         this.school = school;
         this.major = major;
         this.grade = grade;
         this.semester = semester;
         this.onboardingStep = 2;
+    }
+
+    public void withdraw() {
+        this.deletedAt = java.time.LocalDateTime.now();
+    }
+
+    public boolean isWithdrawn() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -48,6 +48,9 @@ public class User extends BaseEntity {
     @Column(name = "onboarding_step", nullable = false)
     private int onboardingStep = 1;
 
+    @Version
+    private Long version;
+
     @Column(name = "deleted_at")
     private java.time.LocalDateTime deletedAt;
 

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -22,6 +22,7 @@ public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "사용자를 찾을 수 없습니다."),
 
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER409_1", "이미 존재하는 사용자입니다."),
+    ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "USER409_2", "이미 탈퇴한 사용자입니다."),
 
     ;
 

--- a/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/exception/UserErrorCode.java
@@ -17,7 +17,8 @@ public enum UserErrorCode implements BaseCode {
     EMAIL_CODE_INVALID(HttpStatus.BAD_REQUEST, "USER4002", "인증 코드가 올바르지 않거나 만료되었습니다."),
     EMAIL_DOMAIN_INVALID(HttpStatus.BAD_REQUEST, "USER4003", "학교 이메일(@ac.kr)만 사용 가능합니다."),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "USER4004", "유효하지 않거나 만료된 토큰입니다."),
-    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다.");
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "USER403", "해당 사용자에 대한 접근 권한이 없습니다."),
+    ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "USER4005", "이미 탈퇴한 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/repository/UserRepository.java
@@ -3,9 +3,16 @@ package com.capstone.pickIt.domain.user.repository;
 import com.capstone.pickIt.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    java.util.Optional<User> findByEmail(String email);
+    Optional<User> findByEmail(String email);
+
+    // 탈퇴 후 30일 지난 사용자 조회 (하드 딜리트용)
+    List<User> findByDeletedAtBeforeAndDeletedAtIsNotNull(LocalDateTime dateTime);
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
@@ -17,7 +17,7 @@ public class UserCleanupScheduler {
     private final UserRepository userRepository;
 
     // 매일 새벽 3시에 탈퇴 후 30일 지난 계정 하드 딜리트
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     @Transactional
     public void deleteWithdrawnUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);

--- a/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.capstone.pickIt.domain.user.service;
+
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserCleanupScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매일 새벽 3시에 탈퇴 후 30일 지난 계정 하드 딜리트
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void deleteWithdrawnUsers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        List<User> targets = userRepository.findByDeletedAtBeforeAndDeletedAtIsNotNull(threshold);
+        userRepository.deleteAll(targets);
+    }
+}

--- a/src/main/java/com/capstone/pickIt/global/config/SchedulerConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.capstone.pickIt.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/capstone/pickIt/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "blacklist:access:";
+    private static final String WITHDRAWN_USER_PREFIX = "withdrawn:user:";
 
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
@@ -46,15 +47,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if(jwtProvider.validateAccessToken(token) && !isBlacklisted) {
 
                 Long userId = jwtProvider.getUserId(token);
-                String email = jwtProvider.getEmail(token);
 
-                AuthPrincipal principal = new AuthPrincipal(userId, email);
+                boolean isWithdrawn = Boolean.TRUE.equals(
+                        redisTemplate.hasKey(WITHDRAWN_USER_PREFIX + userId));
 
-                UsernamePasswordAuthenticationToken authenticationToken =
-                        new UsernamePasswordAuthenticationToken(
-                                principal, null, Collections.emptyList()
-                        );
-                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                if (!isWithdrawn) {
+                    String email = jwtProvider.getEmail(token);
+
+                    AuthPrincipal principal = new AuthPrincipal(userId, email);
+
+                    UsernamePasswordAuthenticationToken authenticationToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    principal, null, Collections.emptyList()
+                            );
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                }
             }
         }
         filterChain.doFilter(request, response);


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #49 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  소프트 딜리트 방식의 회원 탈퇴 기능을 구현했습니다.

  - DELETE /api/users/delete 엔드포인트 추가
  - 탈퇴 시 deletedAt 기록 후 기존 토큰 즉시 무효화 (로그아웃 동시 처리)
  - 이미 탈퇴한 계정 재탈퇴 시도 방어 (ALREADY_WITHDRAWN 에러 코드 추가)
  - UserCleanupScheduler: 매일 새벽 3시에 탈퇴 후 30일 경과한 계정 하드 딜리트
  - SchedulerConfig: @EnableScheduling 활성화



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **계정 탈퇴 기능 추가**: 사용자가 언제든지 계정을 탈퇴할 수 있는 기능이 추가되었습니다. 탈퇴 시 계정은 비활성화되며 로그인이 불가능해집니다. 탈퇴한 계정은 30일 후 시스템에서 자동으로 완전히 삭제됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->