### PR TITLE
[Feat] 팀원 요청 수락 처리 API 구현

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -23,6 +23,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_3",
             "공통 과목 목록 조회에 성공했습니다."
+    ),
+    TEAM_REQUEST_RESPONDED(
+            HttpStatus.OK,
+            "CHAT200_4",
+            "팀원 요청 응답 처리에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -91,12 +91,8 @@ public class ChatRoomController {
     ) {
         Long currentUserId = SecurityUtil.requireUserId();
 
-        TeamRequestResponseDTO.Respond result = null;
-  /*              chatRoomCommandService.acceptTeamRequest(
-                        currentUserId,
-                        chatRoomId,
-                        teamRequestId
-                );*/
+        TeamRequestResponseDTO.Respond result =
+                chatRoomCommandService.acceptTeamRequest(currentUserId, chatRoomId, teamRequestId);
 
         return ApiResponse.onSuccess(
                 ChatSuccessCode.TEAM_REQUEST_RESPONDED,

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -41,11 +41,11 @@ public class ChatRoomController {
         );
     }
 
-    @PostMapping("/{chatRoomId}/team-requests")
     @Operation(
             summary = "팀원 요청 보내기",
             description = "현재 사용자가 1:1 채팅방의 상대 사용자에게 팀원 요청을 보냅니다."
     )
+    @PostMapping("/{chatRoomId}/team-requests")
     public ApiResponse<TeamRequestResponseDTO.Create> createTeamRequest(
             @PathVariable Long chatRoomId,
             @RequestBody @Valid TeamRequestCreateRequestDTO request
@@ -76,6 +76,30 @@ public class ChatRoomController {
 
         return ApiResponse.onSuccess(
                 ChatSuccessCode.COMMON_COURSE_LIST_FETCHED,
+                result
+        );
+    }
+
+    @Operation(
+            summary = "팀원 요청 수락",
+            description = "현재 사용자가 받은 PENDING 상태의 팀원 요청을 수락합니다."
+    )
+    @PatchMapping("/{chatRoomId}/team-requests/{teamRequestId}")
+    public ApiResponse<TeamRequestResponseDTO.Respond> acceptTeamRequest(
+            @PathVariable Long chatRoomId,
+            @PathVariable Long teamRequestId
+    ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        TeamRequestResponseDTO.Respond result = null;
+  /*              chatRoomCommandService.acceptTeamRequest(
+                        currentUserId,
+                        chatRoomId,
+                        teamRequestId
+                );*/
+
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.TEAM_REQUEST_RESPONDED,
                 result
         );
     }

--- a/src/main/java/com/capstone/pickIt/api/chat/converter/TeamRequestConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/TeamRequestConverter.java
@@ -30,4 +30,13 @@ public class TeamRequestConverter {
                 teamRequest.getCreatedAt()
         );
     }
+
+    public static TeamRequestResponseDTO.Respond toRespondResponse(TeamRequest teamRequest) {
+        return new TeamRequestResponseDTO.Respond(
+                teamRequest.getId(),
+                teamRequest.getChatRoom().getId(),
+                teamRequest.getTeamRequestStatus().name(),
+                teamRequest.getRespondedAt()
+        );
+    }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/TeamRequestResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/TeamRequestResponseDTO.java
@@ -16,6 +16,14 @@ public class TeamRequestResponseDTO {
     ) {
     }
 
+    public record Respond(
+            Long teamRequestId,
+            Long chatRoomId,
+            String status,
+            LocalDateTime respondedAt
+    ) {
+    }
+
     public record CourseInfo(
             Long courseId,
             String courseName

--- a/src/main/java/com/capstone/pickIt/api/chat/scheduler/TeamRequestScheduler.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/scheduler/TeamRequestScheduler.java
@@ -1,0 +1,29 @@
+package com.capstone.pickIt.api.chat.scheduler;
+
+import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Component
+@RequiredArgsConstructor
+public class TeamRequestScheduler {
+
+    private final TeamRequestRepository teamRequestRepository;
+    private static final long ONE_HOUR = 60 * 60 * 1000L;
+
+    @Scheduled(fixedDelay = ONE_HOUR)
+    @Transactional
+    public void rejectExpiredPendingTeamRequests() {
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+        LocalDateTime expiredBefore = now.minusHours(24);
+
+        teamRequestRepository.rejectExpiredPendingRequests(expiredBefore, now);
+
+        // TODO: WebSocket 연결 후 만료 처리된 팀원 요청에 대해 TEAM_REQUEST_REJECTED 이벤트 브로드캐스트 구현
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandService.java
@@ -6,6 +6,7 @@ import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
 
 public interface ChatRoomCommandService {
+
     DirectChatRoomResponseDTO.CreateOrEnter createOrEnterDirectChatRoom(
             Long currentUserId,
             DirectChatRoomCreateRequestDTO request
@@ -15,5 +16,11 @@ public interface ChatRoomCommandService {
             Long currentUserId,
             Long chatRoomId,
             TeamRequestCreateRequestDTO request
+    );
+
+    TeamRequestResponseDTO.Respond acceptTeamRequest(
+            Long currentUserId,
+            Long chatRoomId,
+            Long teamRequestId
     );
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -249,11 +249,18 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         boolean existsMember = projectTeamMemberRepository
                 .existsByProjectTeamIdAndUserId(projectTeam.getId(), user.getId());
 
-        if (!existsMember) {
+        if (existsMember) {
+            return;
+        }
+
+        try {
             ProjectTeamMember projectTeamMember =
                     ProjectTeamMember.createPendingMember(projectTeam, user);
 
-            projectTeamMemberRepository.save(projectTeamMember);
+            projectTeamMemberRepository.saveAndFlush(projectTeamMember);
+
+        } catch (DataIntegrityViolationException e) {
+            // 동시에 같은 팀 멤버가 추가된 경우 무시
         }
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -196,11 +196,6 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
         }
 
-        if (teamRequest.isExpired()) {
-            teamRequest.expire();
-            throw new ChatException(ChatErrorCode.TEAM_REQUEST_EXPIRED);
-        }
-
         Course course = teamRequest.getCourse();
         User sender = teamRequest.getSender();
         User receiver = teamRequest.getReceiver();

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -201,7 +201,11 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User receiver = teamRequest.getReceiver();
 
         ProjectTeam projectTeam = projectTeamRepository
-                .findFirstByCourseIdAndStatus(course.getId(), ProjectTeamStatus.RECRUITING)
+                .findRecruitingTeamByCourseAndMember(
+                        course.getId(),
+                        sender.getId(),
+                        receiver.getId()
+                )
                 .orElseGet(() -> projectTeamRepository.save(
                         ProjectTeam.createRecruitingTeam(course)
                 ));

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -168,6 +168,43 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         }
     }
 
+    @Override
+    public TeamRequestResponseDTO.Respond acceptTeamRequest(
+            Long currentUserId,
+            Long chatRoomId,
+            Long teamRequestId
+    ) {
+        TeamRequest teamRequest = teamRequestRepository.findById(teamRequestId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_FOUND));
+
+        if (!teamRequest.getChatRoom().getId().equals(chatRoomId)) {
+            throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_FOUND);
+        }
+
+        if (!teamRequest.isReceiver(currentUserId)) {
+            throw new ChatException(ChatErrorCode.NOT_TEAM_REQUEST_RECEIVER);
+        }
+
+        if (!teamRequest.isPending()) {
+            throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
+        }
+
+        if (teamRequest.isExpired()) {
+            teamRequest.expire();
+            throw new ChatException(ChatErrorCode.TEAM_REQUEST_EXPIRED);
+        }
+
+        teamRequest.accept();
+
+        // TODO: WebSocket 연결 후 TEAM_REQUEST_ACCEPTED 이벤트 브로드캐스트 구현
+        // messagingTemplate.convertAndSend(
+        //        "/topic/chatrooms/" + chatRoomId,
+        //        TeamRequestAcceptedEvent.from(teamRequest)
+        // );
+
+        return TeamRequestConverter.toRespondResponse(teamRequest);
+    }
+
     private DirectChatRoomResponseDTO.CreateOrEnter restoreAndConvert(
             ChatRoom chatRoom,
             Long currentUserId,

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -272,6 +272,10 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
                 .findByUserIdAndCourseIdAndDeletedAtIsNull(userId, courseId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.USER_COURSE_PROFILE_NOT_FOUND));
 
+        if (userCourseProfile.getRecruitmentStatus() != RecruitmentStatus.RECRUITING) {
+            throw new ChatException(ChatErrorCode.INVALID_RECRUITMENT_STATUS);
+        }
+
         userCourseProfile.changeRecruitmentStatus(RecruitmentStatus.CONFIRM_PENDING);
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -14,10 +14,14 @@ import com.capstone.pickIt.domain.chat.entity.ChatRoom;
 import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
 import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
+import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
+import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
 import com.capstone.pickIt.domain.course.repository.CourseRepository;
+import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
 import com.capstone.pickIt.domain.course.repository.UserCourseRepository;
-import com.capstone.pickIt.domain.project.entity.TeamRequest;
-import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
+import com.capstone.pickIt.domain.project.entity.*;
+import com.capstone.pickIt.domain.project.repository.ProjectTeamMemberRepository;
+import com.capstone.pickIt.domain.project.repository.ProjectTeamRepository;
 import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
@@ -39,6 +43,9 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
     private final CourseRepository courseRepository;
     private final UserCourseRepository userCourseRepository;
     private final TeamRequestRepository teamRequestRepository;
+    private final ProjectTeamRepository projectTeamRepository;
+    private final ProjectTeamMemberRepository projectTeamMemberRepository;
+    private final UserCourseProfileRepository userCourseProfileRepository;
 
     @Override
     public DirectChatRoomResponseDTO.CreateOrEnter createOrEnterDirectChatRoom(
@@ -194,6 +201,22 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_EXPIRED);
         }
 
+        Course course = teamRequest.getCourse();
+        User sender = teamRequest.getSender();
+        User receiver = teamRequest.getReceiver();
+
+        ProjectTeam projectTeam = projectTeamRepository
+                .findFirstByCourseIdAndStatus(course.getId(), ProjectTeamStatus.RECRUITING)
+                .orElseGet(() -> projectTeamRepository.save(
+                        ProjectTeam.createRecruitingTeam(course)
+                ));
+
+        addPendingTeamMemberIfNotExists(projectTeam, sender);
+        addPendingTeamMemberIfNotExists(projectTeam, receiver);
+
+        updateCourseProfileToConfirmPending(sender.getId(), course.getId());
+        updateCourseProfileToConfirmPending(receiver.getId(), course.getId());
+
         teamRequest.accept();
 
         // TODO: WebSocket 연결 후 TEAM_REQUEST_ACCEPTED 이벤트 브로드캐스트 구현
@@ -218,5 +241,31 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         currentChatPart.restore();
 
         return ChatRoomConverter.toCreateOrEnterResponse(chatRoom, targetUser, isNew);
+    }
+
+    private void addPendingTeamMemberIfNotExists(
+            ProjectTeam projectTeam,
+            User user
+    ) {
+        boolean existsMember = projectTeamMemberRepository
+                .existsByProjectTeamIdAndUserId(projectTeam.getId(), user.getId());
+
+        if (!existsMember) {
+            ProjectTeamMember projectTeamMember =
+                    ProjectTeamMember.createPendingMember(projectTeam, user);
+
+            projectTeamMemberRepository.save(projectTeamMember);
+        }
+    }
+
+    private void updateCourseProfileToConfirmPending(
+            Long userId,
+            Long courseId
+    ) {
+        UserCourseProfile userCourseProfile = userCourseProfileRepository
+                .findByUserIdAndCourseIdAndDeletedAtIsNull(userId, courseId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.USER_COURSE_PROFILE_NOT_FOUND));
+
+        userCourseProfile.changeRecruitmentStatus(RecruitmentStatus.CONFIRM_PENDING);
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -74,6 +74,11 @@ public enum ChatErrorCode implements BaseCode {
             "CHAT404_6",
             "팀원 요청을 찾을 수 없습니다."
     ),
+    USER_COURSE_PROFILE_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "CHAT404_7",
+            "사용자 과목 프로필을 찾을 수 없습니다."
+    ),
     PENDING_REQUEST_EXISTS_FOR_COURSE(
             HttpStatus.CONFLICT,
             "CHAT409_1",

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -24,10 +24,25 @@ public enum ChatErrorCode implements BaseCode {
             "CHAT400_3",
             "두 사용자의 공통 과목이 아닙니다."
     ),
+    TEAM_REQUEST_NOT_PENDING(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_4",
+            "대기 중인 팀원 요청만 처리할 수 있습니다."
+    ),
+    TEAM_REQUEST_EXPIRED(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_5",
+            "24시간이 지나 만료된 팀원 요청입니다."
+    ),
     NOT_CHAT_ROOM_PARTICIPANT(
             HttpStatus.FORBIDDEN,
             "CHAT403_1",
             "해당 채팅방의 참여자가 아닙니다."
+    ),
+    NOT_TEAM_REQUEST_RECEIVER(
+            HttpStatus.FORBIDDEN,
+            "CHAT403_2",
+            "해당 팀원 요청을 처리할 권한이 없습니다."
     ),
     CURRENT_USER_NOT_FOUND(
             HttpStatus.NOT_FOUND,
@@ -53,6 +68,11 @@ public enum ChatErrorCode implements BaseCode {
             HttpStatus.NOT_FOUND,
             "CHAT404_5",
             "과목을 찾을 수 없습니다."
+    ),
+    TEAM_REQUEST_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "CHAT404_6",
+            "팀원 요청을 찾을 수 없습니다."
     ),
     PENDING_REQUEST_EXISTS_FOR_COURSE(
             HttpStatus.CONFLICT,

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -93,6 +93,11 @@ public enum ChatErrorCode implements BaseCode {
             HttpStatus.CONFLICT,
         "CHAT409_3",
             "대기 중인 팀원 요청이 이미 존재합니다."
+    ),
+    INVALID_RECRUITMENT_STATUS(
+            HttpStatus.CONFLICT,
+            "CHAT409_4",
+            "현재 모집 가능한 상태가 아닙니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
@@ -36,4 +36,9 @@ public interface UserCourseProfileRepository extends JpaRepository<UserCoursePro
             Long currentUserId,
             Long opponentUserId
     );
+
+    Optional<UserCourseProfile> findByUserIdAndCourseIdAndDeletedAtIsNull(
+            Long userId,
+            Long courseId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
@@ -63,4 +63,11 @@ public class ProjectTeam extends BaseEntity {
             this.status = ProjectTeamStatus.RECRUITING;
         }
     }
+
+    public static ProjectTeam createRecruitingTeam(Course course) {
+        return ProjectTeam.builder()
+                .course(course)
+                .status(ProjectTeamStatus.RECRUITING)
+                .build();
+    }
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
@@ -9,11 +9,19 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "project_team")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(
+        name = "project_team",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_project_team_course_status",
+                        columnNames = {"course_id", "status"}
+                )
+        }
+)
 public class ProjectTeam extends BaseEntity {
 
     @Id

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeamMember.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeamMember.java
@@ -1,10 +1,12 @@
 package com.capstone.pickIt.domain.project.entity;
 
+import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.global.entity.CreatedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -106,5 +108,20 @@ public class ProjectTeamMember extends CreatedBaseEntity {
         if (this.recruitmentConfirmStatus == null) {
             this.recruitmentConfirmStatus = RecruitmentConfirmStatus.PENDING;
         }
+    }
+
+    public static ProjectTeamMember createPendingMember(
+            ProjectTeam projectTeam,
+            User user
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return ProjectTeamMember.builder()
+                .projectTeam(projectTeam)
+                .user(user)
+                .role(ProjectTeamMemberRole.MEMBER)
+                .joinedAt(now)
+                .recruitmentConfirmStatus(RecruitmentConfirmStatus.PENDING)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequest.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequest.java
@@ -78,6 +78,24 @@ public class TeamRequest extends CreatedBaseEntity {
         this.pendingUniqueFlag = null;
     }
 
+    public boolean isPending() {
+        return this.teamRequestStatus == TeamRequestStatus.PENDING;
+    }
+
+    public boolean isExpired() {
+        return this.getCreatedAt().plusHours(24).isBefore(LocalDateTime.now(ZoneOffset.UTC));
+    }
+
+    public boolean isReceiver(Long userId) {
+        return this.receiver.getId().equals(userId);
+    }
+
+    public void expire() {
+        this.teamRequestStatus = TeamRequestStatus.REJECTED;
+        this.respondedAt = LocalDateTime.now(ZoneOffset.UTC);
+        this.pendingUniqueFlag = null;
+    }
+
     @PrePersist
     protected void onCreate() {
         if (this.teamRequestStatus == null) {

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequest.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequest.java
@@ -83,7 +83,8 @@ public class TeamRequest extends CreatedBaseEntity {
     }
 
     public boolean isExpired() {
-        return this.getCreatedAt().plusHours(24).isBefore(LocalDateTime.now(ZoneOffset.UTC));
+        LocalDateTime expiredAt = this.getCreatedAt().plusHours(24);
+        return !expiredAt.isAfter(LocalDateTime.now(ZoneOffset.UTC));
     }
 
     public boolean isReceiver(Long userId) {

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMember, Long> {
 
     List<ProjectTeamMember> findByProjectTeam_Id(Long projectTeamId);
+
+    boolean existsByProjectTeamIdAndUserId(Long projectTeamId, Long userId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamRepository.java
@@ -1,7 +1,15 @@
 package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.ProjectTeam;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProjectTeamRepository extends JpaRepository<ProjectTeam, Long> {
+
+    Optional<ProjectTeam> findFirstByCourseIdAndStatus(
+            Long courseId,
+            ProjectTeamStatus status
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamRepository.java
@@ -3,13 +3,24 @@ package com.capstone.pickIt.domain.project.repository;
 import com.capstone.pickIt.domain.project.entity.ProjectTeam;
 import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface ProjectTeamRepository extends JpaRepository<ProjectTeam, Long> {
 
-    Optional<ProjectTeam> findFirstByCourseIdAndStatus(
+    @Query("""
+        SELECT pt
+        FROM ProjectTeam pt
+        JOIN ProjectTeamMember ptm ON ptm.projectTeam = pt
+        WHERE pt.course.id = :courseId
+          AND pt.status = 'RECRUITING'
+          AND ptm.user.id IN (:senderId, :receiverId)
+        ORDER BY pt.createdAt DESC
+        """)
+    Optional<ProjectTeam> findRecruitingTeamByCourseAndMember(
             Long courseId,
-            ProjectTeamStatus status
+            Long senderId,
+            Long receiverId
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -3,6 +3,10 @@ package com.capstone.pickIt.domain.project.repository;
 import com.capstone.pickIt.domain.project.entity.TeamRequest;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
 
 public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> {
 
@@ -22,5 +26,19 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             Long chatRoomId,
             Long receiverId,
             TeamRequestStatus teamRequestStatus
+    );
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE TeamRequest tr
+        SET tr.teamRequestStatus = 'REJECTED',
+            tr.respondedAt = :now,
+            tr.pendingUniqueFlag = null
+        WHERE tr.teamRequestStatus = 'PENDING'
+          AND tr.createdAt < :expiredBefore
+        """)
+    int rejectExpiredPendingRequests(
+            LocalDateTime expiredBefore,
+            LocalDateTime now
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -35,7 +35,7 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             tr.respondedAt = :now,
             tr.pendingUniqueFlag = null
         WHERE tr.teamRequestStatus = 'PENDING'
-          AND tr.createdAt < :expiredBefore
+          AND tr.createdAt <= :expiredBefore
         """)
     int rejectExpiredPendingRequests(
             LocalDateTime expiredBefore,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: pickIt
 
+  jackson:
+    time-zone: UTC
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}
@@ -35,6 +38,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time-zone: UTC
 jwt:
   secret: ${JWT_SECRET}
   access-token-expire-ms: 3600000


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

#59 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

팀원 요청 수락 처리 (`PATCH /api/v1/chats/{chatRoomId}/team-requests/{teamRequestId}`)
- 팀원 요청 receiver만 요청을 수락할 수 있도록 검증 로직 추가
- `PENDING` 상태의 팀원 요청만 수락 가능하도록 구현
- 수락 시 `team_request_status = ACCEPTED`, `responded_at`, `pendingUniqueFlag` 갱신
- 팀원 요청 수락 시 팀 후보 형성 로직 추가
  - 해당 과목의 `RECRUITING` 상태 팀 후보가 없는 경우:
    - `project_team` 생성
    - `project_team_member`에 sender / receiver 추가
    - 두 사용자의 `user_course_profile.recruitment_status`를 `CONFIRM_PENDING`으로 변경
  - 해당 과목의 `RECRUITING` 상태 팀 후보가 이미 존재하는 경우:
    - 기존 팀에 멤버를 추가
- 팀원 요청 생성 후 24시간 동안 수락되지 않은 경우, 자동으로 `REJECTED` 처리하는 스케줄러 추가
- Hibernate timezone을 UTC 기준으로 통일하도록 설정 추가


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1444" height="592" alt="image" src="https://github.com/user-attachments/assets/59cc9c21-c983-4907-bf94-aa46b5483999" />




## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

<img width="1930" height="116" alt="image" src="https://github.com/user-attachments/assets/7af87c23-0883-4098-ac9e-5bb9ae416d72" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.