### PR TITLE
[Refactor] 유저 생성 및 탈퇴 포인트 처리  

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -3,6 +3,11 @@ package com.capstone.pickIt.api.user.service;
 import com.capstone.pickIt.api.user.dto.request.PasswordResetRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UserRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.UserResponseDTO;
+import com.capstone.pickIt.domain.point.entity.Point;
+import com.capstone.pickIt.domain.point.entity.PointTransaction;
+import com.capstone.pickIt.domain.point.entity.PointTransactionType;
+import com.capstone.pickIt.domain.point.repository.PointRepository;
+import com.capstone.pickIt.domain.point.repository.PointTransactionRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.exception.UserErrorCode;
 import com.capstone.pickIt.domain.user.exception.UserException;
@@ -23,8 +28,11 @@ public class UserServiceImpl implements UserService {
     private static final String EMAIL_VERIFIED_PREFIX = "email:verified:";
     private static final String PASSWORD_RESET_VERIFIED_PREFIX = "password:reset:verified:";
     static final String WITHDRAWN_USER_PREFIX = "withdrawn:user:";
+    private static final int SIGNUP_REWARD_AMOUNT = 100;
 
     private final UserRepository userRepository;
+    private final PointRepository pointRepository;
+    private final PointTransactionRepository pointTransactionRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -87,6 +95,20 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         User savedUser = userRepository.save(user);
+
+        Point point = Point.builder()
+                .user(savedUser)
+                .balance(SIGNUP_REWARD_AMOUNT)
+                .build();
+        pointRepository.save(point);
+
+        pointTransactionRepository.save(PointTransaction.builder()
+                .user(savedUser)
+                .transactionType(PointTransactionType.SIGNUP_REWARD)
+                .amount(SIGNUP_REWARD_AMOUNT)
+                .balanceAfter(SIGNUP_REWARD_AMOUNT)
+                .description("회원가입 보상 포인트")
+                .build());
 
         redisTemplate.delete(EMAIL_VERIFIED_PREFIX + email);
 

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.pickIt.domain.point.repository;
+
+import com.capstone.pickIt.domain.point.entity.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PointRepository extends JpaRepository<Point, Long> {
+
+    Optional<Point> findByUserId(Long userId);
+}

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
@@ -2,10 +2,18 @@ package com.capstone.pickIt.domain.point.repository;
 
 import com.capstone.pickIt.domain.point.entity.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
 
     Optional<Point> findByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM Point p WHERE p.user.id IN :userIds")
+    void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointRepository.java
@@ -13,7 +13,7 @@ public interface PointRepository extends JpaRepository<Point, Long> {
 
     Optional<Point> findByUserId(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Point p WHERE p.user.id IN :userIds")
     void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.pickIt.domain.point.repository;
+
+import com.capstone.pickIt.domain.point.entity.PointTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+}

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
@@ -2,6 +2,15 @@ package com.capstone.pickIt.domain.point.repository;
 
 import com.capstone.pickIt.domain.point.entity.PointTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+
+    @Modifying
+    @Query("DELETE FROM PointTransaction pt WHERE pt.user.id IN :userIds")
+    void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/point/repository/PointTransactionRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PointTransaction pt WHERE pt.user.id IN :userIds")
     void deleteAllByUserIdIn(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
@@ -1,5 +1,7 @@
 package com.capstone.pickIt.domain.user.service;
 
+import com.capstone.pickIt.domain.point.repository.PointRepository;
+import com.capstone.pickIt.domain.point.repository.PointTransactionRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import java.util.List;
 public class UserCleanupScheduler {
 
     private final UserRepository userRepository;
+    private final PointTransactionRepository pointTransactionRepository;
+    private final PointRepository pointRepository;
 
     // 매일 새벽 3시에 탈퇴 후 30일 지난 계정 하드 딜리트
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
@@ -22,6 +26,11 @@ public class UserCleanupScheduler {
     public void deleteWithdrawnUsers() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
         List<User> targets = userRepository.findByDeletedAtBeforeAndDeletedAtIsNotNull(threshold);
+
+        List<Long> userIds = targets.stream().map(User::getId).toList();
+        pointTransactionRepository.deleteAllByUserIdIn(userIds);
+        pointRepository.deleteAllByUserIdIn(userIds);
+
         userRepository.deleteAll(targets);
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/service/UserCleanupScheduler.java
@@ -27,6 +27,8 @@ public class UserCleanupScheduler {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
         List<User> targets = userRepository.findByDeletedAtBeforeAndDeletedAtIsNotNull(threshold);
 
+        if (targets.isEmpty()) return;
+
         List<Long> userIds = targets.stream().map(User::getId).toList();
         pointTransactionRepository.deleteAllByUserIdIn(userIds);
         pointRepository.deleteAllByUserIdIn(userIds);


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #76 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

   ### Point/PointTransaction Repository 생성                                        
   - `PointRepository`: `findByUserId`, `deleteAllByUserIdIn` 추가
   - `PointTransactionRepository`: `deleteAllByUserIdIn` 추가
                               
   ### 회원가입 시 포인트 테이블 초기화                                               
   - `UserServiceImpl.signUp()` 에서 유저 저장 후 `Point` 레코드 생성 (초기 잔액 100)                                                      
   - `SIGNUP_REWARD` 타입의 `PointTransaction` 동시 기록
                    
   ### 회원 탈퇴 시 포인트 처리                           
   - **소프트 딜리트(탈퇴 시점)**: Point 테이블 유지 — 30일 유예 기간 동안 데이터 보존
   - **하드 딜리트(스케줄러)**: `UserCleanupScheduler`에서 User 삭제 전`PointTransaction` → `Point` 순서로 먼저 삭제

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원가입 시 가입 보상 포인트(100포인트) 지급 기능 추가
  * 포인트 및 포인트 거래 내역 관리 시스템 구현

* **개선 사항**
  * 사용자 탈퇴 시 포인트 관련 데이터 정리 로직 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->