### PR TITLE
[Hotfix] 온보딩 완료되면 isComplete true 설정

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/OnboardingServiceImpl.java
@@ -88,6 +88,9 @@ public class OnboardingServiceImpl implements OnboardingService {
     @Override
     @Transactional
     public void savePersonality(Long userId, OnboardingPersonalityRequestDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
         List<UserDefaultTraitRequestDTO> traits = request.getTraits().stream()
                 .map(item -> new UserDefaultTraitRequestDTO(item.getTraitItemId(), item.getSelectedType().name()))
                 .toList();
@@ -109,5 +112,7 @@ public class OnboardingServiceImpl implements OnboardingService {
                     .toList();
             userCourseTraitRepository.saveAll(courseTraits);
         }
+
+        user.completeOnboarding();
     }
 }

--- a/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/pickIt/domain/user/entity/User.java
@@ -62,6 +62,11 @@ public class User extends BaseEntity {
         this.onboardingStep = 2;
     }
 
+    public void completeOnboarding() {
+        this.onboardingStep = 3;
+        this.onboardingCompleted = true;
+    }
+
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

 온보딩을 끝까지 완료해도 isCompleted가 계속 false로 반환되는 버그가 발생                                                                                                                                                   
                  
  원인

   savePersonality() (성향 저장) 이후 온보딩 완료 처리 로직이 아예 없었음
  - User.java에 onboardingCompleted를 true로 바꾸는 메서드 자체가 없음
  - OnboardingServiceImpl.savePersonality()에서 유저 엔티티를 조회조차 안 해서 완료 처리 불가


  수정 내용

  1. User.java — completeOnboarding() 메서드 추가: onboardingStep = 3, onboardingCompleted = true
  2. OnboardingServiceImpl.savePersonality() — 메서드 시작에서 유저 조회 추가, 끝에 user.completeOnboarding() 호출 추가
    - @Transactional 안에서 dirty checking으로 자동 저장됨 (명시적 save() 불필요)

  단계 흐름
  - step 1 → 초기 상태
  - step 2 → 기본 정보 저장 완료 후 (기존 동작 정상)
  - step 3 ->  isCompleted: true → savePersonality() 완료 후 (이번 수정)

| 시점 | step 변화 | 위치 |
|---|---|---|
| 회원가입 직후 | 1 (기본값) | `User.java @Builder.Default` |
| POST `/api/users/onboarding/profile` 호출 완료 | 1 → 2 | `User.updateBasicInfo()` |
| POST `/api/users/onboarding/personality` 호출 완료 | 2 → 3 + `isCompleted: true` | `User.completeOnboarding()` (이번에 추가) |


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 온보딩 과정 중 사용자 검증 로직 강화로 안정성 개선

* **새로운 기능**
  * 사용자 성격 특성 정보 저장 완료 후 온보딩 상태가 자동으로 완료 표시되도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->