### PR TITLE
[Feat] 마이페이지 사용자 정보 조회 

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/controller/MypageController.java
+++ b/src/main/java/com/capstone/pickIt/api/user/controller/MypageController.java
@@ -4,9 +4,11 @@ import com.capstone.pickIt.api.user.dto.request.AddCourseRequestDTO;
 import com.capstone.pickIt.api.user.dto.request.UpdateCourseRequestDTO;
 import com.capstone.pickIt.api.user.dto.response.CourseCardResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.CourseListResponseDTO;
+import com.capstone.pickIt.api.user.dto.response.MyPageProfileResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.ProjectHistoryDetailResponseDTO;
 import com.capstone.pickIt.api.user.dto.response.ProjectHistorySummaryResponseDTO;
 import com.capstone.pickIt.api.user.service.MypageCourseService;
+import com.capstone.pickIt.api.user.service.MypageProfileService;
 import com.capstone.pickIt.api.user.service.MypageProjectHistoryService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
 import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
@@ -27,6 +29,14 @@ public class MypageController {
 
     private final MypageCourseService mypageCourseService;
     private final MypageProjectHistoryService mypageProjectHistoryService;
+    private final MypageProfileService mypageProfileService;
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "로그인한 사용자의 닉네임, 학과, 학년, 팀플레벨, 포인트를 조회합니다.")
+    @GetMapping("/me/profile")
+    public ApiResponse<MyPageProfileResponseDTO> getProfile() {
+        Long userId = SecurityUtil.requireUserId();
+        return ApiResponse.onSuccess(SuccessCode.OK, mypageProfileService.getProfile(userId));
+    }
 
     @Operation(summary = "프로젝트 이력 상세 조회", description = "사용자의 프로젝트별 완수율 및 상호평가 점수를 최신순으로 조회합니다.")
     @GetMapping("/me/project-history")

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/MyPageProfileResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/MyPageProfileResponseDTO.java
@@ -1,0 +1,10 @@
+package com.capstone.pickIt.api.user.dto.response;
+
+public record MyPageProfileResponseDTO(
+        String nickname,
+        String major,
+        Integer grade,
+        int teamLevel,
+        int point
+) {
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileService.java
@@ -1,0 +1,8 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.response.MyPageProfileResponseDTO;
+
+public interface MypageProfileService {
+
+    MyPageProfileResponseDTO getProfile(Long userId);
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileServiceImpl.java
@@ -1,0 +1,48 @@
+package com.capstone.pickIt.api.user.service;
+
+import com.capstone.pickIt.api.user.dto.response.MyPageProfileResponseDTO;
+import com.capstone.pickIt.domain.point.entity.Point;
+import com.capstone.pickIt.domain.point.exception.PointErrorCode;
+import com.capstone.pickIt.domain.point.exception.PointException;
+import com.capstone.pickIt.domain.point.repository.PointRepository;
+import com.capstone.pickIt.domain.teamlevel.entity.TeamLevel;
+import com.capstone.pickIt.domain.teamlevel.exception.TeamLevelErrorCode;
+import com.capstone.pickIt.domain.teamlevel.exception.TeamLevelException;
+import com.capstone.pickIt.domain.teamlevel.repository.TeamLevelRepository;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MypageProfileServiceImpl implements MypageProfileService {
+
+    private final UserRepository userRepository;
+    private final PointRepository pointRepository;
+    private final TeamLevelRepository teamLevelRepository;
+
+    @Override
+    public MyPageProfileResponseDTO getProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Point point = pointRepository.findByUserId(userId)
+                .orElseThrow(() -> new PointException(PointErrorCode.POINT_NOT_FOUND));
+
+        TeamLevel teamLevel = teamLevelRepository.findByUserId(userId)
+                .orElseThrow(() -> new TeamLevelException(TeamLevelErrorCode.TEAM_LEVEL_NOT_FOUND));
+
+        return new MyPageProfileResponseDTO(
+                user.getNickname(),
+                user.getMajor(),
+                user.getGrade(),
+                teamLevel.getLevel(),
+                point.getBalance()
+        );
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageProfileServiceImpl.java
@@ -1,13 +1,7 @@
 package com.capstone.pickIt.api.user.service;
 
 import com.capstone.pickIt.api.user.dto.response.MyPageProfileResponseDTO;
-import com.capstone.pickIt.domain.point.entity.Point;
-import com.capstone.pickIt.domain.point.exception.PointErrorCode;
-import com.capstone.pickIt.domain.point.exception.PointException;
 import com.capstone.pickIt.domain.point.repository.PointRepository;
-import com.capstone.pickIt.domain.teamlevel.entity.TeamLevel;
-import com.capstone.pickIt.domain.teamlevel.exception.TeamLevelErrorCode;
-import com.capstone.pickIt.domain.teamlevel.exception.TeamLevelException;
 import com.capstone.pickIt.domain.teamlevel.repository.TeamLevelRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.exception.UserErrorCode;
@@ -31,18 +25,20 @@ public class MypageProfileServiceImpl implements MypageProfileService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        Point point = pointRepository.findByUserId(userId)
-                .orElseThrow(() -> new PointException(PointErrorCode.POINT_NOT_FOUND));
+        int point = pointRepository.findByUserId(userId)
+                .map(p -> p.getBalance())
+                .orElse(0);
 
-        TeamLevel teamLevel = teamLevelRepository.findByUserId(userId)
-                .orElseThrow(() -> new TeamLevelException(TeamLevelErrorCode.TEAM_LEVEL_NOT_FOUND));
+        int teamLevel = teamLevelRepository.findByUserId(userId)
+                .map(t -> t.getLevel())
+                .orElse(0);
 
         return new MyPageProfileResponseDTO(
                 user.getNickname(),
                 user.getMajor(),
                 user.getGrade(),
-                teamLevel.getLevel(),
-                point.getBalance()
+                teamLevel,
+                point
         );
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/UserServiceImpl.java
@@ -8,6 +8,8 @@ import com.capstone.pickIt.domain.point.entity.PointTransaction;
 import com.capstone.pickIt.domain.point.entity.PointTransactionType;
 import com.capstone.pickIt.domain.point.repository.PointRepository;
 import com.capstone.pickIt.domain.point.repository.PointTransactionRepository;
+import com.capstone.pickIt.domain.teamlevel.entity.TeamLevel;
+import com.capstone.pickIt.domain.teamlevel.repository.TeamLevelRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.exception.UserErrorCode;
 import com.capstone.pickIt.domain.user.exception.UserException;
@@ -33,6 +35,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PointRepository pointRepository;
     private final PointTransactionRepository pointTransactionRepository;
+    private final TeamLevelRepository teamLevelRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -108,6 +111,10 @@ public class UserServiceImpl implements UserService {
                 .amount(SIGNUP_REWARD_AMOUNT)
                 .balanceAfter(SIGNUP_REWARD_AMOUNT)
                 .description("회원가입 보상 포인트")
+                .build());
+
+        teamLevelRepository.save(TeamLevel.builder()
+                .user(savedUser)
                 .build());
 
         redisTemplate.delete(EMAIL_VERIFIED_PREFIX + email);

--- a/src/main/java/com/capstone/pickIt/domain/teamlevel/entity/TeamLevel.java
+++ b/src/main/java/com/capstone/pickIt/domain/teamlevel/entity/TeamLevel.java
@@ -1,0 +1,37 @@
+package com.capstone.pickIt.domain.teamlevel.entity;
+
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "team_level",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_team_level_user", columnNames = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TeamLevel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "level_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder.Default
+    @Column(name = "level", nullable = false)
+    private int level = 0;
+
+    public void levelUp() {
+        this.level++;
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/teamlevel/exception/TeamLevelErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/teamlevel/exception/TeamLevelErrorCode.java
@@ -1,0 +1,17 @@
+package com.capstone.pickIt.domain.teamlevel.exception;
+
+import com.capstone.pickIt.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TeamLevelErrorCode implements BaseCode {
+
+    TEAM_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAMLEVEL404_1", "팀플레벨 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/capstone/pickIt/domain/teamlevel/exception/TeamLevelException.java
+++ b/src/main/java/com/capstone/pickIt/domain/teamlevel/exception/TeamLevelException.java
@@ -1,0 +1,18 @@
+package com.capstone.pickIt.domain.teamlevel.exception;
+
+import com.capstone.pickIt.global.apiPayload.exception.CustomException;
+
+public class TeamLevelException extends CustomException {
+
+    public TeamLevelException(TeamLevelErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public TeamLevelException(TeamLevelErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public TeamLevelException(TeamLevelErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/teamlevel/repository/TeamLevelRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/teamlevel/repository/TeamLevelRepository.java
@@ -1,0 +1,11 @@
+package com.capstone.pickIt.domain.teamlevel.repository;
+
+import com.capstone.pickIt.domain.teamlevel.entity.TeamLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamLevelRepository extends JpaRepository<TeamLevel, Long> {
+
+    Optional<TeamLevel> findByUserId(Long userId);
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #101 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.


  마이페이지 사용자 정보 조회 API 구현 (GET /api/users/me/profile)                                                                                                                             
  신규 구현                                                                                                                                                                                 
  - TeamLevel 엔티티 및 Repository 생성 (User 1:1 관계, 기본값 LV.0)
  - GET /api/users/me/profile 엔드포인트 추가
  - Access Token 기반 인증으로 닉네임, 학과, 학년, 팀플레벨, 포인트 반환

  기존 코드 연동
  - 회원가입(signUp) 시 Point, TeamLevel 레코드 함께 생성하도록 수정
  - Point/TeamLevel 레코드 없는 기존 계정은 0으로 fallback 처리



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="877" height="349" alt="image" src="https://github.com/user-attachments/assets/3ee4c711-ba8a-4432-8be8-159964e81201" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

  - 신규 가입 사용자는 팀플레벨 LV.0, 포인트 100(회원가입 보상)으로 시작합니다.
  - 온보딩 미완료 사용자의 경우 major, grade 필드는 null로 반환될 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이페이지 프로필 조회 API 추가 - 사용자 닉네임, 전공, 학년, 팀 레벨, 포인트 정보 조회 가능
  * 팀 레벨 시스템 도입 - 회원가입 시 팀 레벨이 자동으로 초기화되며, 프로필에서 현재 팀 레벨 확인 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->