### PR TITLE
[Feat] 채팅방 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -28,6 +28,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_4",
             "팀원 요청 응답 처리에 성공했습니다."
+    ),
+    CHAT_ROOM_LIST_FOUND(
+            HttpStatus.OK,
+            "CHAT200_5",
+            "채팅방 목록 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -42,6 +42,10 @@ public class ChatRoomController {
         );
     }
 
+    @Operation(
+            summary = "채팅방 목록 조회",
+            description = "현재 사용자가 참여 중인 채팅방 목록을 최신 메시지 순으로 조회합니다."
+    )
     @GetMapping
     public ApiResponse<ChatRoomResponseDTO.ListResponse> getMyChatRooms(
             @RequestParam(required = false) Long cursor

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.capstone.pickIt.api.chat.controller;
 import com.capstone.pickIt.api.chat.code.ChatSuccessCode;
 import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.DirectChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
@@ -38,6 +39,18 @@ public class ChatRoomController {
         return ApiResponse.onSuccess(
                 ChatSuccessCode.DIRECT_CHAT_ROOM_CREATED_OR_ENTERED,
                 result
+        );
+    }
+
+    @GetMapping
+    public ApiResponse<ChatRoomResponseDTO.ListResponse> getMyChatRooms(
+            @RequestParam(required = false) Long cursor
+    ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.CHAT_ROOM_LIST_FOUND,
+                chatRoomQueryService.getMyChatRooms(currentUserId, cursor)
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
@@ -1,0 +1,36 @@
+package com.capstone.pickIt.api.chat.dto.response;
+
+import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
+import com.capstone.pickIt.domain.chat.entity.ChatType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatRoomResponseDTO {
+
+    public record ListResponse(
+            List<ChatRoomSummary> chatRooms,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+    }
+
+    public record ChatRoomSummary(
+            Long chatRoomId,
+            ChatType chatType,
+            Opponent opponent,
+            String roomName,
+            int participantCount,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            long unreadCount,
+            ChatBadgeType badgeType
+    ) {
+    }
+
+    public record Opponent(
+            Long userId,
+            String nickname
+    ) {
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -132,7 +132,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = currentChatPart.getUser();
         User receiver = receiverChatPart.getUser();
 
-        Course course = courseRepository.findById(request.courseId())
+        Course course = courseRepository.findByIdForUpdate(request.courseId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         boolean isCommonCourse = userCourseRepository.existsCommonCourse(
@@ -225,11 +225,13 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
         }
 
-        Course course = teamRequest.getCourse();
+        Course course = courseRepository.findByIdForUpdate(teamRequest.getCourse().getId())
+                .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
+
         User sender = teamRequest.getSender();
         User receiver = teamRequest.getReceiver();
 
-        // 동일 과목 활성 팀 중복 참여 방지 검증
+        // 동일 과목 활성 팀(RECRUITING, IN_PROGRESS) 중복 참여 방지 검증
         validateNotJoinedActiveTeam(course.getId(), sender.getId());
         validateNotJoinedActiveTeam(course.getId(), receiver.getId());
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.capstone.pickIt.domain.point.policy.PointPolicy.PROJECT_REQUIRED_POINT;
@@ -144,6 +145,11 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.NOT_COMMON_COURSE);
         }
 
+        // 동일 과목 활성 팀(RECRUITING, IN_PROGRESS) 중복 참여 방지 검증
+        validateNotJoinedActiveTeam(course.getId(), sender.getId());
+        validateNotJoinedActiveTeam(course.getId(), receiver.getId());
+
+        // 같은 과목에 대해 sender가 보낸 PENDING 팀 요청 존재 여부 검증
         boolean existsPendingForCourse =
                 teamRequestRepository.existsBySenderIdAndCourseIdAndTeamRequestStatus(
                         sender.getId(),
@@ -155,6 +161,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.PENDING_REQUEST_EXISTS_FOR_COURSE);
         }
 
+        // 같은 receiver에게 보낸 PENDING 팀 요청 존재 여부 검증
         boolean existsPendingForReceiver =
                 teamRequestRepository.existsBySenderIdAndReceiverIdAndTeamRequestStatus(
                         sender.getId(),
@@ -166,6 +173,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.PENDING_REQUEST_EXISTS_FOR_RECEIVER);
         }
 
+        // 프로젝트 참여 가능 포인트 보유 여부 검증
         PointResponseDTO point = pointService.refreshAndGetPoint(currentUserId);
 
         if (point.balance() < PROJECT_REQUIRED_POINT) {
@@ -221,6 +229,10 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = teamRequest.getSender();
         User receiver = teamRequest.getReceiver();
 
+        // 동일 과목 활성 팀 중복 참여 방지 검증
+        validateNotJoinedActiveTeam(course.getId(), sender.getId());
+        validateNotJoinedActiveTeam(course.getId(), receiver.getId());
+
         ProjectTeam projectTeam = projectTeamRepository
                 .findRecruitingTeamByCourseAndMember(
                         course.getId(),
@@ -262,6 +274,25 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         currentChatPart.restore();
 
         return ChatRoomConverter.toCreateOrEnterResponse(chatRoom, targetUser, isNew);
+    }
+
+    private void validateNotJoinedActiveTeam(
+            Long courseId,
+            Long userId
+    ) {
+        boolean existsActiveTeam = projectTeamMemberRepository
+                .existsActiveTeamByCourseAndUser(
+                        courseId,
+                        userId,
+                        List.of(
+                                ProjectTeamStatus.RECRUITING,
+                                ProjectTeamStatus.IN_PROGRESS
+                        )
+                );
+
+        if (existsActiveTeam) {
+            throw new ChatException(ChatErrorCode.ALREADY_JOINED_ACTIVE_TEAM);
+        }
     }
 
     private void addPendingTeamMemberIfNotExists(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -132,7 +132,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = currentChatPart.getUser();
         User receiver = receiverChatPart.getUser();
 
-        Course course = courseRepository.findByIdForUpdate(request.courseId())
+        Course course = courseRepository.findByIdWithLock(request.courseId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         boolean isCommonCourse = userCourseRepository.existsCommonCourse(
@@ -210,7 +210,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             Long chatRoomId,
             Long teamRequestId
     ) {
-        TeamRequest teamRequest = teamRequestRepository.findById(teamRequestId)
+        TeamRequest teamRequest = teamRequestRepository.findByIdWithLock(teamRequestId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_FOUND));
 
         if (!teamRequest.getChatRoom().getId().equals(chatRoomId)) {
@@ -225,7 +225,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
         }
 
-        Course course = courseRepository.findByIdForUpdate(teamRequest.getCourse().getId())
+        Course course = courseRepository.findByIdWithLock(teamRequest.getCourse().getId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         User sender = teamRequest.getSender();

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
@@ -1,5 +1,6 @@
 package com.capstone.pickIt.api.chat.service;
 
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 
 public interface ChatRoomQueryService {
@@ -7,5 +8,10 @@ public interface ChatRoomQueryService {
     CommonCourseResponseDTO.CommonCourseList getCommonCourses(
             Long currentUserId,
             Long chatRoomId
+    );
+
+    ChatRoomResponseDTO.ListResponse getMyChatRooms(
+            Long currentUserId,
+            Long cursor
     );
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -22,7 +22,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -111,8 +115,53 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
             chatParts = chatParts.subList(0, PAGE_SIZE);
         }
 
+        List<Long> chatRoomIds = chatParts.stream()
+                .map(chatPart -> chatPart.getChatRoom().getId())
+                .toList();
+
+        Map<Long, Long> unreadCountMap = messageRepository
+                .countUnreadMessagesByChatRoomIds(chatRoomIds, currentUserId)
+                .stream()
+                .collect(Collectors.toMap(
+                        MessageRepository.UnreadCountProjection::getChatRoomId,
+                        MessageRepository.UnreadCountProjection::getUnreadCount
+                ));
+
+        Map<Long, Long> participantCountMap = chatPartRepository
+                .countParticipantsByChatRoomIds(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatPartRepository.ParticipantCountProjection::getChatRoomId,
+                        ChatPartRepository.ParticipantCountProjection::getParticipantCount
+                ));
+
+        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = chatPartRepository
+                .findOpponentsByChatRoomIds(chatRoomIds, currentUserId)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatPartRepository.OpponentProjection::getChatRoomId,
+                        opponent -> new ChatRoomResponseDTO.Opponent(
+                                opponent.getUserId(),
+                                opponent.getNickname()
+                        )
+                ));
+
+        Set<Long> pendingRequestChatRoomIds = new HashSet<>(
+                teamRequestRepository.findPendingRequestChatRoomIds(
+                        chatRoomIds,
+                        currentUserId,
+                        TeamRequestStatus.PENDING
+                )
+        );
+
         List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
-                .map(chatPart -> toChatRoomSummary(chatPart, currentUserId))
+                .map(chatPart -> toChatRoomSummary(
+                        chatPart,
+                        unreadCountMap,
+                        participantCountMap,
+                        opponentMap,
+                        pendingRequestChatRoomIds
+                ))
                 .toList();
 
         Long nextCursor = hasNext
@@ -128,12 +177,19 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(
             ChatPart myChatPart,
-            Long currentUserId
+            Map<Long, Long> unreadCountMap,
+            Map<Long, Long> participantCountMap,
+            Map<Long, ChatRoomResponseDTO.Opponent> opponentMap,
+            Set<Long> pendingRequestChatRoomIds
     ) {
         ChatRoom chatRoom = myChatPart.getChatRoom();
+        Long chatRoomId = chatRoom.getId();
 
-        long unreadCount = getUnreadCount(chatRoom, myChatPart, currentUserId);
-        boolean hasPendingTeamRequest = hasPendingTeamRequest(chatRoom, currentUserId);
+        long unreadCount = unreadCountMap.getOrDefault(chatRoomId, 0L);
+
+        boolean hasPendingTeamRequest =
+                chatRoom.getChatType() == ChatType.DIRECT
+                        && pendingRequestChatRoomIds.contains(chatRoomId);
 
         ChatBadgeType badgeType = resolveBadgeType(
                 chatRoom,
@@ -141,24 +197,17 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 unreadCount
         );
 
-        ChatRoomResponseDTO.Opponent opponent = null;
+        ChatRoomResponseDTO.Opponent opponent =
+                chatRoom.getChatType() == ChatType.DIRECT
+                        ? opponentMap.get(chatRoomId)
+                        : null;
 
-        if (chatRoom.getChatType() == ChatType.DIRECT) {
-            ChatPart opponentChatPart = chatPartRepository
-                    .findOpponent(chatRoom.getId(), currentUserId)
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
-
-            opponent = new ChatRoomResponseDTO.Opponent(
-                    opponentChatPart.getUser().getId(),
-                    opponentChatPart.getUser().getNickname()
-            );
-        }
-
-        int participantCount = chatPartRepository
-                .countByChatRoomIdAndDeletedAtIsNull(chatRoom.getId());
+        int participantCount = participantCountMap
+                .getOrDefault(chatRoomId, 0L)
+                .intValue();
 
         return new ChatRoomResponseDTO.ChatRoomSummary(
-                chatRoom.getId(),
+                chatRoomId,
                 chatRoom.getChatType(),
                 opponent,
                 chatRoom.getRoomName(),
@@ -167,37 +216,6 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 chatRoom.getLastMessageAt(),
                 unreadCount,
                 badgeType
-        );
-    }
-
-    private long getUnreadCount(
-            ChatRoom chatRoom,
-            ChatPart myChatPart,
-            Long currentUserId
-    ) {
-        Long lastReadMessageId = myChatPart.getLastReadMessage() == null
-                ? null
-                : myChatPart.getLastReadMessage().getId();
-
-        return messageRepository.countUnreadMessages(
-                chatRoom.getId(),
-                currentUserId,
-                lastReadMessageId
-        );
-    }
-
-    private boolean hasPendingTeamRequest(
-            ChatRoom chatRoom,
-            Long currentUserId
-    ) {
-        if (chatRoom.getChatType() != ChatType.DIRECT) {
-            return false;
-        }
-
-        return teamRequestRepository.existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
-                chatRoom.getId(),
-                currentUserId,
-                TeamRequestStatus.PENDING
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -1,7 +1,9 @@
 package com.capstone.pickIt.api.chat.service;
 
 import com.capstone.pickIt.api.chat.converter.CommonCourseConverter;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
+import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
 import com.capstone.pickIt.domain.chat.entity.ChatRoom;
 import com.capstone.pickIt.domain.chat.entity.ChatType;
@@ -9,14 +11,17 @@ import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
 import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
 import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
+import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -24,10 +29,13 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
+    private static final int PAGE_SIZE = 20;
+
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;
     private final UserCourseProfileRepository userCourseProfileRepository;
     private final TeamRequestRepository teamRequestRepository;
+    private final MessageRepository messageRepository;
 
     @Override
     public CommonCourseResponseDTO.CommonCourseList getCommonCourses(
@@ -72,5 +80,145 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         );
 
         return CommonCourseConverter.toCommonCourseList(commonCourses);
+    }
+
+    @Override
+    public ChatRoomResponseDTO.ListResponse getMyChatRooms(
+            Long currentUserId,
+            Long cursor
+    ) {
+        LocalDateTime cursorLastMessageAt = null;
+
+        if (cursor != null) {
+            cursorLastMessageAt = chatRoomRepository.findById(cursor)
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND))
+                    .getLastMessageAt();
+        }
+
+        List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(
+                currentUserId,
+                cursor,
+                cursorLastMessageAt,
+                PageRequest.of(0, PAGE_SIZE + 1)
+        );
+
+        boolean hasNext = chatParts.size() > PAGE_SIZE;
+
+        if (hasNext) {
+            chatParts = chatParts.subList(0, PAGE_SIZE);
+        }
+
+        List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
+                .map(chatPart -> toChatRoomSummary(chatPart, currentUserId))
+                .toList();
+
+        Long nextCursor = hasNext
+                ? chatRooms.get(chatRooms.size() - 1).chatRoomId()
+                : null;
+
+        return new ChatRoomResponseDTO.ListResponse(
+                chatRooms,
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(
+            ChatPart myChatPart,
+            Long currentUserId
+    ) {
+        ChatRoom chatRoom = myChatPart.getChatRoom();
+
+        long unreadCount = getUnreadCount(chatRoom, myChatPart, currentUserId);
+        boolean hasPendingTeamRequest = hasPendingTeamRequest(chatRoom, currentUserId);
+
+        ChatBadgeType badgeType = resolveBadgeType(
+                chatRoom,
+                hasPendingTeamRequest,
+                unreadCount
+        );
+
+        ChatRoomResponseDTO.Opponent opponent = null;
+
+        if (chatRoom.getChatType() == ChatType.DIRECT) {
+            ChatPart opponentChatPart = chatPartRepository
+                    .findOpponent(chatRoom.getId(), currentUserId)
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
+
+            opponent = new ChatRoomResponseDTO.Opponent(
+                    opponentChatPart.getUser().getId(),
+                    opponentChatPart.getUser().getNickname()
+            );
+        }
+
+        int participantCount = chatPartRepository
+                .countByChatRoomIdAndDeletedAtIsNull(chatRoom.getId());
+
+        return new ChatRoomResponseDTO.ChatRoomSummary(
+                chatRoom.getId(),
+                chatRoom.getChatType(),
+                opponent,
+                chatRoom.getRoomName(),
+                participantCount,
+                getLastMessageContent(chatRoom),
+                chatRoom.getLastMessageAt(),
+                unreadCount,
+                badgeType
+        );
+    }
+
+    private long getUnreadCount(
+            ChatRoom chatRoom,
+            ChatPart myChatPart,
+            Long currentUserId
+    ) {
+        Long lastReadMessageId = myChatPart.getLastReadMessage() == null
+                ? null
+                : myChatPart.getLastReadMessage().getId();
+
+        return messageRepository.countUnreadMessages(
+                chatRoom.getId(),
+                currentUserId,
+                lastReadMessageId
+        );
+    }
+
+    private boolean hasPendingTeamRequest(
+            ChatRoom chatRoom,
+            Long currentUserId
+    ) {
+        if (chatRoom.getChatType() != ChatType.DIRECT) {
+            return false;
+        }
+
+        return teamRequestRepository.existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
+                chatRoom.getId(),
+                currentUserId,
+                TeamRequestStatus.PENDING
+        );
+    }
+
+    private ChatBadgeType resolveBadgeType(
+            ChatRoom chatRoom,
+            boolean hasPendingTeamRequest,
+            long unreadCount
+    ) {
+        if (chatRoom.getChatType() == ChatType.DIRECT && hasPendingTeamRequest) {
+            return ChatBadgeType.TEAM_REQUEST;
+        }
+
+        if (unreadCount > 0) {
+            return ChatBadgeType.UNREAD_MESSAGE;
+        }
+
+        return ChatBadgeType.NONE;
+    }
+
+    private String getLastMessageContent(ChatRoom chatRoom) {
+        if (chatRoom.getLastMessage() == null) {
+            return null;
+        }
+
+        return chatRoom.getLastMessage().getContent();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -90,9 +90,12 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         LocalDateTime cursorLastMessageAt = null;
 
         if (cursor != null) {
-            cursorLastMessageAt = chatRoomRepository.findById(cursor)
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND))
-                    .getLastMessageAt();
+            ChatPart cursorChatPart = chatPartRepository
+                    .findByChatRoomIdAndUserId(cursor, currentUserId)
+                    .filter(chatPart -> !chatPart.isDeleted())
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT));
+
+            cursorLastMessageAt = cursorChatPart.getChatRoom().getLastMessageAt();
         }
 
         List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -145,8 +145,16 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                         ChatPartRepository.ParticipantCountProjection::getParticipantCount
                 ));
 
-        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = chatPartRepository
-                .findOpponentsByChatRoomIds(chatRoomIds, currentUserId)
+        List<Long> directChatRoomIds = chatParts.stream()
+                .map(ChatPart::getChatRoom)
+                .filter(chatRoom -> chatRoom.getChatType() == ChatType.DIRECT)
+                .map(ChatRoom::getId)
+                .toList();
+
+        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = directChatRoomIds.isEmpty()
+                ? Map.of()
+                : chatPartRepository
+                .findOpponentsByChatRoomIds(directChatRoomIds, currentUserId)
                 .stream()
                 .collect(Collectors.toMap(
                         ChatPartRepository.OpponentProjection::getChatRoomId,

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
-    private static final int PAGE_SIZE = 20;
+    private static final int PAGE_SIZE = 15;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -115,6 +115,16 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
             chatParts = chatParts.subList(0, PAGE_SIZE);
         }
 
+        // 조회 결과가 없으면, 배치 조회를 수행하지 않고 빈 응답 반환
+        if (chatParts.isEmpty()) {
+            return new ChatRoomResponseDTO.ListResponse(
+                    List.of(),
+                    null,
+                    false
+            );
+        }
+
+        // 배치 조회를 위한 채팅방 ID 목록 추출
         List<Long> chatRoomIds = chatParts.stream()
                 .map(chatPart -> chatPart.getChatRoom().getId())
                 .toList();
@@ -154,6 +164,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 )
         );
 
+        // 배치 조회 결과를 조합하여 채팅방 응답 DTO 생성
         List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
                 .map(chatPart -> toChatRoomSummary(
                         chatPart,

--- a/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatBadgeType.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatBadgeType.java
@@ -1,0 +1,7 @@
+package com.capstone.pickIt.domain.chat.entity;
+
+public enum ChatBadgeType {
+    TEAM_REQUEST,
+    UNREAD_MESSAGE,
+    NONE
+}

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -128,6 +128,11 @@ public enum ChatErrorCode implements BaseCode {
             HttpStatus.CONFLICT,
             "CHAT409_4",
             "현재 모집 가능한 상태가 아닙니다."
+    ),
+    ALREADY_JOINED_ACTIVE_TEAM(
+            HttpStatus.CONFLICT,
+            "CHAT409_5",
+            "이미 해당 과목의 모집 중이거나 진행 중인 팀에 참여 중입니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -1,9 +1,13 @@
 package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
@@ -29,4 +33,27 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
               AND cp.deletedAt IS NULL
             """)
     int countActiveParticipants(Long chatRoomId);
+
+    @Query("""
+        SELECT cp
+        FROM ChatPart cp
+        JOIN FETCH cp.chatRoom cr
+        LEFT JOIN FETCH cr.lastMessage lm
+        WHERE cp.user.id = :userId
+        AND cp.deletedAt IS NULL
+        AND (
+          :cursor IS NULL
+          OR cr.lastMessageAt < :cursorLastMessageAt
+          OR (cr.lastMessageAt = :cursorLastMessageAt AND cr.id < :cursor)
+        )
+        ORDER BY cr.lastMessageAt DESC, cr.id DESC
+    """)
+    List<ChatPart> findMyChatRooms(
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
+            @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            Pageable pageable
+    );
+
+    int countByChatRoomIdAndDeletedAtIsNull(Long chatRoomId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -55,5 +55,40 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             Pageable pageable
     );
 
-    int countByChatRoomIdAndDeletedAtIsNull(Long chatRoomId);
+    public interface ParticipantCountProjection {
+        Long getChatRoomId();
+        Long getParticipantCount();
+    }
+
+    public interface OpponentProjection {
+        Long getChatRoomId();
+        Long getUserId();
+        String getNickname();
+    }
+
+    @Query("""
+        SELECT cp.chatRoom.id AS chatRoomId,
+               COUNT(cp) AS participantCount
+        FROM ChatPart cp
+        WHERE cp.chatRoom.id IN :chatRoomIds
+        AND cp.deletedAt IS NULL
+        GROUP BY cp.chatRoom.id
+    """)
+    List<ParticipantCountProjection> countParticipantsByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds
+    );
+
+    @Query("""
+        SELECT cp.chatRoom.id AS chatRoomId,
+               cp.user.id AS userId,
+               cp.user.nickname AS nickname
+        FROM ChatPart cp
+        WHERE cp.chatRoom.id IN :chatRoomIds
+        AND cp.user.id <> :currentUserId
+        AND cp.deletedAt IS NULL
+    """)
+    List<OpponentProjection> findOpponentsByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -2,6 +2,24 @@ package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    @Query("""
+        SELECT COUNT(m)
+        FROM Message m
+        WHERE m.chatRoom.id = :chatRoomId
+        AND m.sender.id <> :currentUserId
+        AND (
+          :lastReadMessageId IS NULL
+          OR m.id > :lastReadMessageId
+        )
+    """)
+    long countUnreadMessages(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("currentUserId") Long currentUserId,
+            @Param("lastReadMessageId") Long lastReadMessageId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -5,21 +5,32 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+    public interface UnreadCountProjection {
+        Long getChatRoomId();
+        Long getUnreadCount();
+    }
+
     @Query("""
-        SELECT COUNT(m)
+        SELECT m.chatRoom.id AS chatRoomId,
+               COUNT(m) AS unreadCount
         FROM Message m
-        WHERE m.chatRoom.id = :chatRoomId
+        JOIN ChatPart cp
+        ON cp.chatRoom.id = m.chatRoom.id
+        AND cp.user.id = :currentUserId
+        WHERE m.chatRoom.id IN :chatRoomIds
         AND m.user.id <> :currentUserId
         AND (
-          :lastReadMessageId IS NULL
-          OR m.id > :lastReadMessageId
+            cp.lastReadMessage IS NULL
+            OR m.id > cp.lastReadMessage.id
         )
+        GROUP BY m.chatRoom.id
     """)
-    long countUnreadMessages(
-            @Param("chatRoomId") Long chatRoomId,
-            @Param("currentUserId") Long currentUserId,
-            @Param("lastReadMessageId") Long lastReadMessageId
+    List<UnreadCountProjection> countUnreadMessagesByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -11,7 +11,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         SELECT COUNT(m)
         FROM Message m
         WHERE m.chatRoom.id = :chatRoomId
-        AND m.sender.id <> :currentUserId
+        AND m.user.id <> :currentUserId
         AND (
           :lastReadMessageId IS NULL
           OR m.id > :lastReadMessageId

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
@@ -1,11 +1,19 @@
 package com.capstone.pickIt.domain.course.repository;
 
 import com.capstone.pickIt.domain.course.entity.Course;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
     Optional<Course> findByCourseNameAndSemester(String courseName, String semester);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Course c WHERE c.id = :courseId")
+    Optional<Course> findByIdForUpdate(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
@@ -15,5 +15,5 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Course c WHERE c.id = :courseId")
-    Optional<Course> findByIdForUpdate(@Param("courseId") Long courseId);
+    Optional<Course> findByIdWithLock(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.ProjectTeamMember;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,20 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
 
     boolean existsByProjectTeamIdAndUserId(Long projectTeamId, Long userId);
 
+    @Query("""
+        SELECT COUNT(ptm) > 0
+        FROM ProjectTeamMember ptm
+        JOIN ptm.projectTeam pt
+        WHERE pt.course.id = :courseId
+        AND ptm.user.id = :userId
+        AND ptm.leftAt IS NULL
+        AND pt.status IN :statuses
+    """)
+    boolean existsActiveTeamByCourseAndUser(
+            @Param("courseId") Long courseId,
+            @Param("userId") Long userId,
+            @Param("statuses") List<ProjectTeamStatus> statuses
+    );
 
     List<ProjectTeamMember> findAllByUserIdAndRecruitmentConfirmStatusAndLeftAtIsNullOrderByJoinedAtDesc(
             Long userId,

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> {
@@ -33,13 +34,20 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             Pageable pageable
     );
 
-    boolean existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
-            Long chatRoomId,
-            Long receiverId,
-            TeamRequestStatus teamRequestStatus
-    );
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT tr FROM TeamRequest tr WHERE tr.id = :teamRequestId")
     Optional<TeamRequest> findByIdWithLock(@Param("teamRequestId") Long teamRequestId);
+
+    @Query("""
+        SELECT tr.chatRoom.id
+        FROM TeamRequest tr
+        WHERE tr.chatRoom.id IN :chatRoomIds
+        AND tr.receiver.id = :currentUserId
+        AND tr.teamRequestStatus = :status
+    """)
+    List<Long> findPendingRequestChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId,
+            @Param("status") TeamRequestStatus status
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -2,11 +2,16 @@ package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.TeamRequest;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> {
 
@@ -33,4 +38,8 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             Long receiverId,
             TeamRequestStatus teamRequestStatus
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT tr FROM TeamRequest tr WHERE tr.id = :teamRequestId")
+    Optional<TeamRequest> findByIdWithLock(@Param("teamRequestId") Long teamRequestId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -27,4 +27,10 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             LocalDateTime createdAt,
             Pageable pageable
     );
+
+    boolean existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
+            Long chatRoomId,
+            Long receiverId,
+            TeamRequestStatus teamRequestStatus
+    );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #27 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

채팅방 목록 조회 API 구현 (`GET /api/chats`)
- `chat_part.deleted_at IS NULL` 조건으로 참여 중인 채팅방만 조회
- `chat_room.last_message_at DESC` 기준 최신 메시지 순 정렬
- 커서 기반 페이징 적용
- `chat_room.last_message_id` 기준 마지막 메시지 내용 조회
- `chat_part.last_read_message_id` 기준 unreadCount 계산
- 현재 사용자가 receiver이고 `PENDING` 상태인 팀원 요청 여부 조회
- badgeType 계산 로직 추가
  - DIRECT + PENDING 팀원 요청 → `TEAM_REQUEST`
  - unreadCount > 0 → `UNREAD_MESSAGE`
  - 그 외 → `NONE`

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1332" height="990" alt="채팅방 목록 조회" src="https://github.com/user-attachments/assets/fbf487bf-c7a2-43fe-9a85-1adebe5bace8" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 목록 조회 API가 추가되었습니다.
  * 커서 기반 페이지네이션으로 채팅방을 효율적으로 탐색할 수 있습니다.
  * 채팅방 목록에 마지막 메시지, 읽지 않은 메시지 수, 참여 인원, 상대 정보 및 배지(팀 요청/읽지 않음/없음)가 표시됩니다.

* **버그 수정**
  * 동일 과목의 진행 중인 팀에 중복 참여되는 문제가 방지되도록 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->