### PR TITLE
[Feat] 채팅방 나가기 API 구현

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -28,6 +28,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_4",
             "팀원 요청 응답 처리에 성공했습니다."
+    ),
+    CHAT_ROOM_LIST_FOUND(
+            HttpStatus.OK,
+            "CHAT200_5",
+            "채팅방 목록 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -38,6 +38,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_6",
             "채팅방 메시지 목록 조회에 성공했습니다."
+    ),
+    CHAT_ROOM_LEFT(
+            HttpStatus.OK,
+            "CHAT200_7",
+            "채팅방 나가기에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -33,6 +33,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_5",
             "채팅방 목록 조회에 성공했습니다."
+    ),
+    CHAT_MESSAGE_LIST_FETCHED(
+            HttpStatus.OK,
+            "CHAT200_6",
+            "채팅방 메시지 목록 조회에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -42,6 +42,10 @@ public class ChatRoomController {
         );
     }
 
+    @Operation(
+            summary = "채팅방 목록 조회",
+            description = "현재 사용자가 참여 중인 채팅방 목록을 최신 메시지 순으로 조회합니다."
+    )
     @GetMapping
     public ApiResponse<ChatRoomResponseDTO.ListResponse> getMyChatRooms(
             @RequestParam(required = false) Long cursor

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -84,6 +84,22 @@ public class ChatRoomController {
     }
 
     @Operation(
+            summary = "채팅방 나가기",
+            description = "현재 사용자를 해당 채팅방에서 나간 상태로 변경합니다."
+    )
+    @PatchMapping("/{chatRoomId}/leave")
+    public ApiResponse<ChatRoomResponseDTO.LeaveResponse> leaveChatRoom(
+            @PathVariable Long chatRoomId
+    ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.CHAT_ROOM_LEFT,
+                chatRoomCommandService.leaveChatRoom(currentUserId, chatRoomId)
+        );
+    }
+
+    @Operation(
             summary = "팀원 요청 보내기",
             description = "현재 사용자가 1:1 채팅방의 상대 사용자에게 팀원 요청을 보냅니다."
     )

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -14,6 +14,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @Tag(name = "Chat", description = "채팅 API")
 @RestController
 @RequiredArgsConstructor
@@ -45,13 +47,18 @@ public class ChatRoomController {
     )
     @GetMapping
     public ApiResponse<ChatRoomResponseDTO.ListResponse> getMyChatRooms(
-            @RequestParam(required = false) Long cursor
+            @RequestParam(required = false) LocalDateTime cursorLastMessageAt,
+            @RequestParam(required = false) Long cursorChatRoomId
     ) {
         Long currentUserId = SecurityUtil.requireUserId();
 
         return ApiResponse.onSuccess(
                 ChatSuccessCode.CHAT_ROOM_LIST_FOUND,
-                chatRoomQueryService.getMyChatRooms(currentUserId, cursor)
+                chatRoomQueryService.getMyChatRooms(
+                        currentUserId,
+                        cursorLastMessageAt,
+                        cursorChatRoomId
+                )
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.capstone.pickIt.api.chat.controller;
 import com.capstone.pickIt.api.chat.code.ChatSuccessCode;
 import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.DirectChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
@@ -38,6 +39,18 @@ public class ChatRoomController {
         return ApiResponse.onSuccess(
                 ChatSuccessCode.DIRECT_CHAT_ROOM_CREATED_OR_ENTERED,
                 result
+        );
+    }
+
+    @GetMapping
+    public ApiResponse<ChatRoomResponseDTO.ListResponse> getMyChatRooms(
+            @RequestParam(required = false) Long cursor
+    ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.CHAT_ROOM_LIST_FOUND,
+                chatRoomQueryService.getMyChatRooms(currentUserId, cursor)
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -3,10 +3,7 @@ package com.capstone.pickIt.api.chat.controller;
 import com.capstone.pickIt.api.chat.code.ChatSuccessCode;
 import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
-import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
-import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
-import com.capstone.pickIt.api.chat.dto.response.DirectChatRoomResponseDTO;
-import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
+import com.capstone.pickIt.api.chat.dto.response.*;
 import com.capstone.pickIt.api.chat.service.ChatRoomCommandService;
 import com.capstone.pickIt.api.chat.service.ChatRoomQueryService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
@@ -55,6 +52,27 @@ public class ChatRoomController {
         return ApiResponse.onSuccess(
                 ChatSuccessCode.CHAT_ROOM_LIST_FOUND,
                 chatRoomQueryService.getMyChatRooms(currentUserId, cursor)
+        );
+    }
+
+    @Operation(
+            summary = "채팅방 메시지 목록 조회",
+            description = "특정 채팅방의 메시지 목록을 커서 기반으로 조회합니다."
+    )
+    @GetMapping("/{chatRoomId}/messages")
+    public ApiResponse<ChatMessageResponseDTO.ListResponse> getChatMessages(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long cursor
+    ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.CHAT_MESSAGE_LIST_FETCHED,
+                chatRoomQueryService.getChatMessages(
+                        currentUserId,
+                        chatRoomId,
+                        cursor
+                )
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/converter/ChatMessageConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/ChatMessageConverter.java
@@ -1,0 +1,82 @@
+package com.capstone.pickIt.api.chat.converter;
+
+import com.capstone.pickIt.api.chat.dto.response.ChatMessageResponseDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
+import com.capstone.pickIt.domain.chat.entity.ChatPart;
+import com.capstone.pickIt.domain.chat.entity.ChatRoom;
+import com.capstone.pickIt.domain.chat.entity.Message;
+import com.capstone.pickIt.domain.project.entity.TeamRequest;
+import com.capstone.pickIt.domain.project.entity.TeamRequestRole;
+
+import java.util.List;
+import java.util.Map;
+
+public class ChatMessageConverter {
+
+    public static ChatMessageResponseDTO.ListResponse toListResponse(
+            ChatRoom chatRoom,
+            Integer participantCount,
+            ChatRoomResponseDTO.Opponent opponent,
+            ChatMessageResponseDTO.TeamRequestInfo teamRequest,
+            List<ChatMessageResponseDTO.MessageSummary> messages,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+        return new ChatMessageResponseDTO.ListResponse(
+                chatRoom.getId(),
+                chatRoom.getChatType(),
+                chatRoom.getRoomName(),
+                participantCount,
+                opponent,
+                teamRequest,
+                messages,
+                nextCursor,
+                hasNext
+        );
+    }
+
+    public static ChatMessageResponseDTO.MessageSummary toMessageSummary(
+            Message message,
+            Long currentUserId,
+            Map<Long, Long> unreadCountMap
+    ) {
+        return new ChatMessageResponseDTO.MessageSummary(
+                message.getId(),
+                new ChatMessageResponseDTO.Sender(
+                        message.getUser().getId(),
+                        message.getUser().getNickname()
+                ),
+                message.getMessageType(),
+                message.getContent(),
+                List.of(),
+                message.getCreatedAt(),
+                message.getUser().getId().equals(currentUserId),
+                unreadCountMap.getOrDefault(message.getId(), 0L)
+        );
+    }
+
+    public static ChatRoomResponseDTO.Opponent toOpponent(
+            ChatPart opponentChatPart
+    ) {
+        return new ChatRoomResponseDTO.Opponent(
+                opponentChatPart.getUser().getId(),
+                opponentChatPart.getUser().getNickname()
+        );
+    }
+
+    public static ChatMessageResponseDTO.TeamRequestInfo toTeamRequestInfo(
+            TeamRequest teamRequest,
+            Long currentUserId
+    ) {
+        TeamRequestRole role = teamRequest.getSender().getId().equals(currentUserId)
+                ? TeamRequestRole.SENDER
+                : TeamRequestRole.RECEIVER;
+
+        return new ChatMessageResponseDTO.TeamRequestInfo(
+                teamRequest.getId(),
+                teamRequest.getTeamRequestStatus(),
+                role
+        );
+    }
+
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomConverter.java
@@ -1,9 +1,13 @@
 package com.capstone.pickIt.api.chat.converter;
 
+import com.capstone.pickIt.api.chat.dto.response.ChatMessageResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.DirectChatRoomResponseDTO;
 import com.capstone.pickIt.domain.chat.entity.ChatRoom;
+import com.capstone.pickIt.domain.chat.entity.Message;
 import com.capstone.pickIt.domain.user.entity.User;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class ChatRoomConverter {
@@ -26,6 +30,29 @@ public class ChatRoomConverter {
                 new DirectChatRoomResponseDTO.Opponent(
                         opponent.getId(),
                         opponent.getNickname()
+                )
+        );
+    }
+
+    public static ChatMessageResponseDTO.MessageSummary toMessage(
+            Message message,
+            Long currentUserId,
+            Map<Long, Long> unreadCountMap
+    ) {
+        return new ChatMessageResponseDTO.MessageSummary(
+                message.getId(),
+                new ChatMessageResponseDTO.Sender(
+                        message.getUser().getId(),
+                        message.getUser().getNickname()
+                ),
+                message.getMessageType(),
+                message.getContent(),
+                List.of(),
+                message.getCreatedAt(),
+                message.getUser().getId().equals(currentUserId),
+                unreadCountMap.getOrDefault(
+                        message.getId(),
+                        0L
                 )
         );
     }

--- a/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomConverter.java
@@ -34,26 +34,4 @@ public class ChatRoomConverter {
         );
     }
 
-    public static ChatMessageResponseDTO.MessageSummary toMessage(
-            Message message,
-            Long currentUserId,
-            Map<Long, Long> unreadCountMap
-    ) {
-        return new ChatMessageResponseDTO.MessageSummary(
-                message.getId(),
-                new ChatMessageResponseDTO.Sender(
-                        message.getUser().getId(),
-                        message.getUser().getNickname()
-                ),
-                message.getMessageType(),
-                message.getContent(),
-                List.of(),
-                message.getCreatedAt(),
-                message.getUser().getId().equals(currentUserId),
-                unreadCountMap.getOrDefault(
-                        message.getId(),
-                        0L
-                )
-        );
-    }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatMessageResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatMessageResponseDTO.java
@@ -14,7 +14,7 @@ public class ChatMessageResponseDTO {
             Long chatRoomId,
             ChatType chatType,
             String roomName,
-            int participantCount,
+            Integer participantCount,
             ChatRoomResponseDTO.Opponent opponent,
             TeamRequestInfo teamRequest,
             List<MessageSummary> messages,

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatMessageResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatMessageResponseDTO.java
@@ -1,0 +1,59 @@
+package com.capstone.pickIt.api.chat.dto.response;
+
+import com.capstone.pickIt.domain.chat.entity.ChatType;
+import com.capstone.pickIt.domain.chat.entity.MessageType;
+import com.capstone.pickIt.domain.project.entity.TeamRequestRole;
+import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatMessageResponseDTO {
+
+    public record ListResponse(
+            Long chatRoomId,
+            ChatType chatType,
+            String roomName,
+            int participantCount,
+            ChatRoomResponseDTO.Opponent opponent,
+            TeamRequestInfo teamRequest,
+            List<MessageSummary> messages,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+    }
+
+    public record TeamRequestInfo(
+            Long teamRequestId,
+            TeamRequestStatus status,
+            TeamRequestRole role
+    ) {
+    }
+
+    public record MessageSummary(
+            Long messageId,
+            Sender sender,
+            MessageType messageType,
+            String content,
+            List<FileInfo> files,
+            LocalDateTime createdAt,
+            boolean isMine,
+            long unreadMemberCount
+    ) {
+    }
+
+    public record Sender(
+            Long userId,
+            String nickname
+    ) {
+    }
+
+    public record FileInfo(
+            Long fileId,
+            String fileName,
+            String fileUrl,
+            Long fileSize,
+            String contentType
+    ) {
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
@@ -3,7 +3,6 @@ package com.capstone.pickIt.api.chat.dto.response;
 import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
 import com.capstone.pickIt.domain.chat.entity.ChatType;
 
-import java.awt.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -38,6 +37,13 @@ public class ChatRoomResponseDTO {
     public record Cursor(
             LocalDateTime lastMessageAt,
             Long chatRoomId
+    ) {
+    }
+
+    public record LeaveResponse(
+            Long chatRoomId,
+            ChatType chatType,
+            LocalDateTime deletedAt
     ) {
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
@@ -1,0 +1,36 @@
+package com.capstone.pickIt.api.chat.dto.response;
+
+import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
+import com.capstone.pickIt.domain.chat.entity.ChatType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatRoomResponseDTO {
+
+    public record ListResponse(
+            List<ChatRoomSummary> chatRooms,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+    }
+
+    public record ChatRoomSummary(
+            Long chatRoomId,
+            ChatType chatType,
+            Opponent opponent,
+            String roomName,
+            int participantCount,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            long unreadCount,
+            ChatBadgeType badgeType
+    ) {
+    }
+
+    public record Opponent(
+            Long userId,
+            String nickname
+    ) {
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomResponseDTO.java
@@ -3,6 +3,7 @@ package com.capstone.pickIt.api.chat.dto.response;
 import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
 import com.capstone.pickIt.domain.chat.entity.ChatType;
 
+import java.awt.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -10,7 +11,7 @@ public class ChatRoomResponseDTO {
 
     public record ListResponse(
             List<ChatRoomSummary> chatRooms,
-            Long nextCursor,
+            Cursor nextCursor,
             boolean hasNext
     ) {
     }
@@ -31,6 +32,12 @@ public class ChatRoomResponseDTO {
     public record Opponent(
             Long userId,
             String nickname
+    ) {
+    }
+
+    public record Cursor(
+            LocalDateTime lastMessageAt,
+            Long chatRoomId
     ) {
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandService.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.api.chat.service;
 
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.DirectChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
@@ -10,6 +11,11 @@ public interface ChatRoomCommandService {
     DirectChatRoomResponseDTO.CreateOrEnter createOrEnterDirectChatRoom(
             Long currentUserId,
             DirectChatRoomCreateRequestDTO request
+    );
+
+    ChatRoomResponseDTO.LeaveResponse leaveChatRoom(
+            Long currentUserId,
+            Long chatRoomId
     );
 
     TeamRequestResponseDTO.Create createTeamRequest(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.capstone.pickIt.api.chat.converter.ChatRoomEventConverter;
 import com.capstone.pickIt.api.chat.converter.TeamRequestConverter;
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.response.ChatRoomEventResponseDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.TeamRequestResponseDTO;
 import com.capstone.pickIt.api.chat.event.ChatRoomBroadcastEvent;
 import com.capstone.pickIt.api.point.dto.response.PointResponseDTO;
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.capstone.pickIt.domain.point.policy.PointPolicy.PROJECT_REQUIRED_POINT;
@@ -102,6 +104,32 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
 
             return restoreAndConvert(chatRoom, currentUserId, targetUser, false);
         }
+    }
+
+    @Override
+    public ChatRoomResponseDTO.LeaveResponse leaveChatRoom(
+            Long currentUserId,
+            Long chatRoomId
+    ) {
+        ChatPart chatPart = chatPartRepository
+                .findByChatRoomIdAndUserId(chatRoomId, currentUserId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT));
+
+        if (chatPart.isDeleted()) {
+            throw new ChatException(ChatErrorCode.ALREADY_LEFT_CHAT_ROOM);
+        }
+
+        ChatRoom chatRoom = chatPart.getChatRoom();
+
+        validateCanLeaveChatRoom(chatRoom);
+
+        chatPart.leave();
+
+        return new ChatRoomResponseDTO.LeaveResponse(
+                chatRoom.getId(),
+                chatRoom.getChatType(),
+                chatPart.getDeletedAt()
+        );
     }
 
     @Override
@@ -276,6 +304,21 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         currentChatPart.restore();
 
         return ChatRoomConverter.toCreateOrEnterResponse(chatRoom, targetUser, isNew);
+    }
+
+    private void validateCanLeaveChatRoom(ChatRoom chatRoom) {
+
+        if (chatRoom.getChatType() == ChatType.DIRECT) {
+            return;
+        }
+
+        if (chatRoom.getProjectTeam().getStatus()
+                == ProjectTeamStatus.IN_PROGRESS) {
+
+            throw new ChatException(
+                    ChatErrorCode.CANNOT_LEAVE_IN_PROGRESS_GROUP_CHAT
+            );
+        }
     }
 
     private void validateNotJoinedActiveTeam(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -132,7 +132,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = currentChatPart.getUser();
         User receiver = receiverChatPart.getUser();
 
-        Course course = courseRepository.findById(request.courseId())
+        Course course = courseRepository.findByIdForUpdate(request.courseId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         boolean isCommonCourse = userCourseRepository.existsCommonCourse(
@@ -225,11 +225,13 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
         }
 
-        Course course = teamRequest.getCourse();
+        Course course = courseRepository.findByIdForUpdate(teamRequest.getCourse().getId())
+                .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
+
         User sender = teamRequest.getSender();
         User receiver = teamRequest.getReceiver();
 
-        // 동일 과목 활성 팀 중복 참여 방지 검증
+        // 동일 과목 활성 팀(RECRUITING, IN_PROGRESS) 중복 참여 방지 검증
         validateNotJoinedActiveTeam(course.getId(), sender.getId());
         validateNotJoinedActiveTeam(course.getId(), receiver.getId());
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -112,7 +112,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             Long chatRoomId
     ) {
         ChatPart chatPart = chatPartRepository
-                .findByChatRoomIdAndUserId(chatRoomId, currentUserId)
+                .findByChatRoomIdAndUserIdWithLock(chatRoomId, currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT));
 
         if (chatPart.isDeleted()) {

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.capstone.pickIt.domain.point.policy.PointPolicy.PROJECT_REQUIRED_POINT;
@@ -144,6 +145,11 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.NOT_COMMON_COURSE);
         }
 
+        // 동일 과목 활성 팀(RECRUITING, IN_PROGRESS) 중복 참여 방지 검증
+        validateNotJoinedActiveTeam(course.getId(), sender.getId());
+        validateNotJoinedActiveTeam(course.getId(), receiver.getId());
+
+        // 같은 과목에 대해 sender가 보낸 PENDING 팀 요청 존재 여부 검증
         boolean existsPendingForCourse =
                 teamRequestRepository.existsBySenderIdAndCourseIdAndTeamRequestStatus(
                         sender.getId(),
@@ -155,6 +161,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.PENDING_REQUEST_EXISTS_FOR_COURSE);
         }
 
+        // 같은 receiver에게 보낸 PENDING 팀 요청 존재 여부 검증
         boolean existsPendingForReceiver =
                 teamRequestRepository.existsBySenderIdAndReceiverIdAndTeamRequestStatus(
                         sender.getId(),
@@ -166,6 +173,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.PENDING_REQUEST_EXISTS_FOR_RECEIVER);
         }
 
+        // 프로젝트 참여 가능 포인트 보유 여부 검증
         PointResponseDTO point = pointService.refreshAndGetPoint(currentUserId);
 
         if (point.balance() < PROJECT_REQUIRED_POINT) {
@@ -221,6 +229,10 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = teamRequest.getSender();
         User receiver = teamRequest.getReceiver();
 
+        // 동일 과목 활성 팀 중복 참여 방지 검증
+        validateNotJoinedActiveTeam(course.getId(), sender.getId());
+        validateNotJoinedActiveTeam(course.getId(), receiver.getId());
+
         ProjectTeam projectTeam = projectTeamRepository
                 .findRecruitingTeamByCourseAndMember(
                         course.getId(),
@@ -262,6 +274,25 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         currentChatPart.restore();
 
         return ChatRoomConverter.toCreateOrEnterResponse(chatRoom, targetUser, isNew);
+    }
+
+    private void validateNotJoinedActiveTeam(
+            Long courseId,
+            Long userId
+    ) {
+        boolean existsActiveTeam = projectTeamMemberRepository
+                .existsActiveTeamByCourseAndUser(
+                        courseId,
+                        userId,
+                        List.of(
+                                ProjectTeamStatus.RECRUITING,
+                                ProjectTeamStatus.IN_PROGRESS
+                        )
+                );
+
+        if (existsActiveTeam) {
+            throw new ChatException(ChatErrorCode.ALREADY_JOINED_ACTIVE_TEAM);
+        }
     }
 
     private void addPendingTeamMemberIfNotExists(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -132,7 +132,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         User sender = currentChatPart.getUser();
         User receiver = receiverChatPart.getUser();
 
-        Course course = courseRepository.findByIdForUpdate(request.courseId())
+        Course course = courseRepository.findByIdWithLock(request.courseId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         boolean isCommonCourse = userCourseRepository.existsCommonCourse(
@@ -210,7 +210,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             Long chatRoomId,
             Long teamRequestId
     ) {
-        TeamRequest teamRequest = teamRequestRepository.findById(teamRequestId)
+        TeamRequest teamRequest = teamRequestRepository.findByIdWithLock(teamRequestId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_FOUND));
 
         if (!teamRequest.getChatRoom().getId().equals(chatRoomId)) {
@@ -225,7 +225,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
             throw new ChatException(ChatErrorCode.TEAM_REQUEST_NOT_PENDING);
         }
 
-        Course course = courseRepository.findByIdForUpdate(teamRequest.getCourse().getId())
+        Course course = courseRepository.findByIdWithLock(teamRequest.getCourse().getId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.COURSE_NOT_FOUND));
 
         User sender = teamRequest.getSender();

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
@@ -1,5 +1,6 @@
 package com.capstone.pickIt.api.chat.service;
 
+import com.capstone.pickIt.api.chat.dto.response.ChatMessageResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 
@@ -12,6 +13,12 @@ public interface ChatRoomQueryService {
 
     ChatRoomResponseDTO.ListResponse getMyChatRooms(
             Long currentUserId,
+            Long cursor
+    );
+
+    ChatMessageResponseDTO.ListResponse getChatMessages(
+            Long currentUserId,
+            Long chatRoomId,
             Long cursor
     );
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
@@ -1,5 +1,6 @@
 package com.capstone.pickIt.api.chat.service;
 
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 
 public interface ChatRoomQueryService {
@@ -7,5 +8,10 @@ public interface ChatRoomQueryService {
     CommonCourseResponseDTO.CommonCourseList getCommonCourses(
             Long currentUserId,
             Long chatRoomId
+    );
+
+    ChatRoomResponseDTO.ListResponse getMyChatRooms(
+            Long currentUserId,
+            Long cursor
     );
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryService.java
@@ -4,6 +4,8 @@ import com.capstone.pickIt.api.chat.dto.response.ChatMessageResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
 
+import java.time.LocalDateTime;
+
 public interface ChatRoomQueryService {
 
     CommonCourseResponseDTO.CommonCourseList getCommonCourses(
@@ -13,7 +15,8 @@ public interface ChatRoomQueryService {
 
     ChatRoomResponseDTO.ListResponse getMyChatRooms(
             Long currentUserId,
-            Long cursor
+            LocalDateTime cursorLastMessageAt,
+            Long cursorChatRoomId
     );
 
     ChatMessageResponseDTO.ListResponse getChatMessages(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -22,7 +22,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -111,8 +115,53 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
             chatParts = chatParts.subList(0, PAGE_SIZE);
         }
 
+        List<Long> chatRoomIds = chatParts.stream()
+                .map(chatPart -> chatPart.getChatRoom().getId())
+                .toList();
+
+        Map<Long, Long> unreadCountMap = messageRepository
+                .countUnreadMessagesByChatRoomIds(chatRoomIds, currentUserId)
+                .stream()
+                .collect(Collectors.toMap(
+                        MessageRepository.UnreadCountProjection::getChatRoomId,
+                        MessageRepository.UnreadCountProjection::getUnreadCount
+                ));
+
+        Map<Long, Long> participantCountMap = chatPartRepository
+                .countParticipantsByChatRoomIds(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatPartRepository.ParticipantCountProjection::getChatRoomId,
+                        ChatPartRepository.ParticipantCountProjection::getParticipantCount
+                ));
+
+        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = chatPartRepository
+                .findOpponentsByChatRoomIds(chatRoomIds, currentUserId)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatPartRepository.OpponentProjection::getChatRoomId,
+                        opponent -> new ChatRoomResponseDTO.Opponent(
+                                opponent.getUserId(),
+                                opponent.getNickname()
+                        )
+                ));
+
+        Set<Long> pendingRequestChatRoomIds = new HashSet<>(
+                teamRequestRepository.findPendingRequestChatRoomIds(
+                        chatRoomIds,
+                        currentUserId,
+                        TeamRequestStatus.PENDING
+                )
+        );
+
         List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
-                .map(chatPart -> toChatRoomSummary(chatPart, currentUserId))
+                .map(chatPart -> toChatRoomSummary(
+                        chatPart,
+                        unreadCountMap,
+                        participantCountMap,
+                        opponentMap,
+                        pendingRequestChatRoomIds
+                ))
                 .toList();
 
         Long nextCursor = hasNext
@@ -128,12 +177,19 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(
             ChatPart myChatPart,
-            Long currentUserId
+            Map<Long, Long> unreadCountMap,
+            Map<Long, Long> participantCountMap,
+            Map<Long, ChatRoomResponseDTO.Opponent> opponentMap,
+            Set<Long> pendingRequestChatRoomIds
     ) {
         ChatRoom chatRoom = myChatPart.getChatRoom();
+        Long chatRoomId = chatRoom.getId();
 
-        long unreadCount = getUnreadCount(chatRoom, myChatPart, currentUserId);
-        boolean hasPendingTeamRequest = hasPendingTeamRequest(chatRoom, currentUserId);
+        long unreadCount = unreadCountMap.getOrDefault(chatRoomId, 0L);
+
+        boolean hasPendingTeamRequest =
+                chatRoom.getChatType() == ChatType.DIRECT
+                        && pendingRequestChatRoomIds.contains(chatRoomId);
 
         ChatBadgeType badgeType = resolveBadgeType(
                 chatRoom,
@@ -141,24 +197,17 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 unreadCount
         );
 
-        ChatRoomResponseDTO.Opponent opponent = null;
+        ChatRoomResponseDTO.Opponent opponent =
+                chatRoom.getChatType() == ChatType.DIRECT
+                        ? opponentMap.get(chatRoomId)
+                        : null;
 
-        if (chatRoom.getChatType() == ChatType.DIRECT) {
-            ChatPart opponentChatPart = chatPartRepository
-                    .findOpponent(chatRoom.getId(), currentUserId)
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
-
-            opponent = new ChatRoomResponseDTO.Opponent(
-                    opponentChatPart.getUser().getId(),
-                    opponentChatPart.getUser().getNickname()
-            );
-        }
-
-        int participantCount = chatPartRepository
-                .countByChatRoomIdAndDeletedAtIsNull(chatRoom.getId());
+        int participantCount = participantCountMap
+                .getOrDefault(chatRoomId, 0L)
+                .intValue();
 
         return new ChatRoomResponseDTO.ChatRoomSummary(
-                chatRoom.getId(),
+                chatRoomId,
                 chatRoom.getChatType(),
                 opponent,
                 chatRoom.getRoomName(),
@@ -167,37 +216,6 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 chatRoom.getLastMessageAt(),
                 unreadCount,
                 badgeType
-        );
-    }
-
-    private long getUnreadCount(
-            ChatRoom chatRoom,
-            ChatPart myChatPart,
-            Long currentUserId
-    ) {
-        Long lastReadMessageId = myChatPart.getLastReadMessage() == null
-                ? null
-                : myChatPart.getLastReadMessage().getId();
-
-        return messageRepository.countUnreadMessages(
-                chatRoom.getId(),
-                currentUserId,
-                lastReadMessageId
-        );
-    }
-
-    private boolean hasPendingTeamRequest(
-            ChatRoom chatRoom,
-            Long currentUserId
-    ) {
-        if (chatRoom.getChatType() != ChatType.DIRECT) {
-            return false;
-        }
-
-        return teamRequestRepository.existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
-                chatRoom.getId(),
-                currentUserId,
-                TeamRequestStatus.PENDING
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -1,7 +1,9 @@
 package com.capstone.pickIt.api.chat.service;
 
 import com.capstone.pickIt.api.chat.converter.CommonCourseConverter;
+import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
+import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
 import com.capstone.pickIt.domain.chat.entity.ChatRoom;
 import com.capstone.pickIt.domain.chat.entity.ChatType;
@@ -9,14 +11,17 @@ import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
 import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
 import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
+import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -24,10 +29,13 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
+    private static final int PAGE_SIZE = 20;
+
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;
     private final UserCourseProfileRepository userCourseProfileRepository;
     private final TeamRequestRepository teamRequestRepository;
+    private final MessageRepository messageRepository;
 
     @Override
     public CommonCourseResponseDTO.CommonCourseList getCommonCourses(
@@ -72,5 +80,145 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         );
 
         return CommonCourseConverter.toCommonCourseList(commonCourses);
+    }
+
+    @Override
+    public ChatRoomResponseDTO.ListResponse getMyChatRooms(
+            Long currentUserId,
+            Long cursor
+    ) {
+        LocalDateTime cursorLastMessageAt = null;
+
+        if (cursor != null) {
+            cursorLastMessageAt = chatRoomRepository.findById(cursor)
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND))
+                    .getLastMessageAt();
+        }
+
+        List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(
+                currentUserId,
+                cursor,
+                cursorLastMessageAt,
+                PageRequest.of(0, PAGE_SIZE + 1)
+        );
+
+        boolean hasNext = chatParts.size() > PAGE_SIZE;
+
+        if (hasNext) {
+            chatParts = chatParts.subList(0, PAGE_SIZE);
+        }
+
+        List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
+                .map(chatPart -> toChatRoomSummary(chatPart, currentUserId))
+                .toList();
+
+        Long nextCursor = hasNext
+                ? chatRooms.get(chatRooms.size() - 1).chatRoomId()
+                : null;
+
+        return new ChatRoomResponseDTO.ListResponse(
+                chatRooms,
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(
+            ChatPart myChatPart,
+            Long currentUserId
+    ) {
+        ChatRoom chatRoom = myChatPart.getChatRoom();
+
+        long unreadCount = getUnreadCount(chatRoom, myChatPart, currentUserId);
+        boolean hasPendingTeamRequest = hasPendingTeamRequest(chatRoom, currentUserId);
+
+        ChatBadgeType badgeType = resolveBadgeType(
+                chatRoom,
+                hasPendingTeamRequest,
+                unreadCount
+        );
+
+        ChatRoomResponseDTO.Opponent opponent = null;
+
+        if (chatRoom.getChatType() == ChatType.DIRECT) {
+            ChatPart opponentChatPart = chatPartRepository
+                    .findOpponent(chatRoom.getId(), currentUserId)
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
+
+            opponent = new ChatRoomResponseDTO.Opponent(
+                    opponentChatPart.getUser().getId(),
+                    opponentChatPart.getUser().getNickname()
+            );
+        }
+
+        int participantCount = chatPartRepository
+                .countByChatRoomIdAndDeletedAtIsNull(chatRoom.getId());
+
+        return new ChatRoomResponseDTO.ChatRoomSummary(
+                chatRoom.getId(),
+                chatRoom.getChatType(),
+                opponent,
+                chatRoom.getRoomName(),
+                participantCount,
+                getLastMessageContent(chatRoom),
+                chatRoom.getLastMessageAt(),
+                unreadCount,
+                badgeType
+        );
+    }
+
+    private long getUnreadCount(
+            ChatRoom chatRoom,
+            ChatPart myChatPart,
+            Long currentUserId
+    ) {
+        Long lastReadMessageId = myChatPart.getLastReadMessage() == null
+                ? null
+                : myChatPart.getLastReadMessage().getId();
+
+        return messageRepository.countUnreadMessages(
+                chatRoom.getId(),
+                currentUserId,
+                lastReadMessageId
+        );
+    }
+
+    private boolean hasPendingTeamRequest(
+            ChatRoom chatRoom,
+            Long currentUserId
+    ) {
+        if (chatRoom.getChatType() != ChatType.DIRECT) {
+            return false;
+        }
+
+        return teamRequestRepository.existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
+                chatRoom.getId(),
+                currentUserId,
+                TeamRequestStatus.PENDING
+        );
+    }
+
+    private ChatBadgeType resolveBadgeType(
+            ChatRoom chatRoom,
+            boolean hasPendingTeamRequest,
+            long unreadCount
+    ) {
+        if (chatRoom.getChatType() == ChatType.DIRECT && hasPendingTeamRequest) {
+            return ChatBadgeType.TEAM_REQUEST;
+        }
+
+        if (unreadCount > 0) {
+            return ChatBadgeType.UNREAD_MESSAGE;
+        }
+
+        return ChatBadgeType.NONE;
+    }
+
+    private String getLastMessageContent(ChatRoom chatRoom) {
+        if (chatRoom.getLastMessage() == null) {
+            return null;
+        }
+
+        return chatRoom.getLastMessage().getContent();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -90,9 +90,12 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         LocalDateTime cursorLastMessageAt = null;
 
         if (cursor != null) {
-            cursorLastMessageAt = chatRoomRepository.findById(cursor)
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND))
-                    .getLastMessageAt();
+            ChatPart cursorChatPart = chatPartRepository
+                    .findByChatRoomIdAndUserId(cursor, currentUserId)
+                    .filter(chatPart -> !chatPart.isDeleted())
+                    .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT));
+
+            cursorLastMessageAt = cursorChatPart.getChatRoom().getLastMessageAt();
         }
 
         List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -89,14 +89,14 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     @Override
     public ChatRoomResponseDTO.ListResponse getMyChatRooms(
             Long currentUserId,
-            LocalDateTime cursorLastMessageAt,
+            LocalDateTime cursorSortAt,
             Long cursorChatRoomId
     ) {
-        validateCursor(cursorLastMessageAt, cursorChatRoomId);
+        validateCursor(cursorSortAt, cursorChatRoomId);
 
         List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(
                 currentUserId,
-                cursorLastMessageAt,
+                cursorSortAt,
                 cursorChatRoomId,
                 PageRequest.of(0, ROOM_PAGE_SIZE + 1)
         );
@@ -175,10 +175,12 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 ))
                 .toList();
 
+        ChatRoom lastChatRoom = chatParts.get(chatParts.size() - 1).getChatRoom();
+
         ChatRoomResponseDTO.Cursor nextCursor = hasNext
                 ? new ChatRoomResponseDTO.Cursor(
-                chatRooms.get(chatRooms.size() - 1).lastMessageAt(),
-                chatRooms.get(chatRooms.size() - 1).chatRoomId()
+                    getSortAt(lastChatRoom),
+                    lastChatRoom.getId()
                 )
                 : null;
 
@@ -287,6 +289,12 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         if ((cursorLastMessageAt == null) != (cursorChatRoomId == null)) {
             throw new ChatException(ChatErrorCode.INVALID_CURSOR);
         }
+    }
+
+    private LocalDateTime getSortAt(ChatRoom chatRoom) {
+        return chatRoom.getLastMessageAt() != null
+                ? chatRoom.getLastMessageAt()
+                : chatRoom.getCreatedAt();
     }
 
     private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
-    private static final int PAGE_SIZE = 15;
-    private static final int MESSAGE_PAGE_SIZE = 15;
+    private static final int ROOM_PAGE_SIZE = 15;
+    private static final int MESSAGE_PAGE_SIZE = 20;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;
@@ -106,13 +106,13 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 currentUserId,
                 cursor,
                 cursorLastMessageAt,
-                PageRequest.of(0, PAGE_SIZE + 1)
+                PageRequest.of(0, ROOM_PAGE_SIZE + 1)
         );
 
-        boolean hasNext = chatParts.size() > PAGE_SIZE;
+        boolean hasNext = chatParts.size() > ROOM_PAGE_SIZE;
 
         if (hasNext) {
-            chatParts = chatParts.subList(0, PAGE_SIZE);
+            chatParts = chatParts.subList(0, ROOM_PAGE_SIZE);
         }
 
         // 조회 결과가 없으면, 배치 조회를 수행하지 않고 빈 응답 반환
@@ -226,13 +226,13 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         List<Message> messages = messageRepository.findMessages(
                 chatRoomId,
                 cursor,
-                PageRequest.of(0, PAGE_SIZE + 1)
+                PageRequest.of(0, MESSAGE_PAGE_SIZE + 1)
         );
 
-        boolean hasNext = messages.size() > PAGE_SIZE;
+        boolean hasNext = messages.size() > MESSAGE_PAGE_SIZE;
 
         if (hasNext) {
-            messages = messages.subList(0, PAGE_SIZE);
+            messages = messages.subList(0, MESSAGE_PAGE_SIZE);
         }
 
         if (messages.isEmpty()) {

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -145,8 +145,16 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                         ChatPartRepository.ParticipantCountProjection::getParticipantCount
                 ));
 
-        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = chatPartRepository
-                .findOpponentsByChatRoomIds(chatRoomIds, currentUserId)
+        List<Long> directChatRoomIds = chatParts.stream()
+                .map(ChatPart::getChatRoom)
+                .filter(chatRoom -> chatRoom.getChatType() == ChatType.DIRECT)
+                .map(ChatRoom::getId)
+                .toList();
+
+        Map<Long, ChatRoomResponseDTO.Opponent> opponentMap = directChatRoomIds.isEmpty()
+                ? Map.of()
+                : chatPartRepository
+                .findOpponentsByChatRoomIds(directChatRoomIds, currentUserId)
                 .stream()
                 .collect(Collectors.toMap(
                         ChatPartRepository.OpponentProjection::getChatRoomId,

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -1,12 +1,11 @@
 package com.capstone.pickIt.api.chat.service;
 
+import com.capstone.pickIt.api.chat.converter.ChatMessageConverter;
 import com.capstone.pickIt.api.chat.converter.CommonCourseConverter;
+import com.capstone.pickIt.api.chat.dto.response.ChatMessageResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.CommonCourseResponseDTO;
-import com.capstone.pickIt.domain.chat.entity.ChatBadgeType;
-import com.capstone.pickIt.domain.chat.entity.ChatPart;
-import com.capstone.pickIt.domain.chat.entity.ChatRoom;
-import com.capstone.pickIt.domain.chat.entity.ChatType;
+import com.capstone.pickIt.domain.chat.entity.*;
 import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
 import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
@@ -34,6 +33,7 @@ import java.util.stream.Collectors;
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     private static final int PAGE_SIZE = 15;
+    private static final int MESSAGE_PAGE_SIZE = 15;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;
@@ -194,6 +194,97 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         );
     }
 
+    @Override
+    public ChatMessageResponseDTO.ListResponse getChatMessages(
+            Long currentUserId,
+            Long chatRoomId,
+            Long cursor
+    ) {
+        ChatPart myChatPart = chatPartRepository
+                .findByChatRoomIdAndUserId(chatRoomId, currentUserId)
+                .orElseThrow(() ->
+                        new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT)
+                );
+
+        if (myChatPart.isDeleted()) {
+            throw new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT);
+        }
+
+        ChatRoom chatRoom = myChatPart.getChatRoom();
+
+        ChatRoomResponseDTO.Opponent opponent =
+                getOpponentOrNull(chatRoom, chatRoomId, currentUserId);
+
+        ChatMessageResponseDTO.TeamRequestInfo teamRequest =
+                getTeamRequestOrNull(chatRoom, chatRoomId, currentUserId);
+
+        Integer participantCount =
+                chatRoom.getChatType() == ChatType.GROUP
+                        ? chatPartRepository.countActiveParticipants(chatRoomId)
+                        : null;
+
+        List<Message> messages = messageRepository.findMessages(
+                chatRoomId,
+                cursor,
+                PageRequest.of(0, PAGE_SIZE + 1)
+        );
+
+        boolean hasNext = messages.size() > PAGE_SIZE;
+
+        if (hasNext) {
+            messages = messages.subList(0, PAGE_SIZE);
+        }
+
+        if (messages.isEmpty()) {
+            return ChatMessageConverter.toListResponse(
+                    chatRoom,
+                    participantCount,
+                    opponent,
+                    teamRequest,
+                    List.of(),
+                    null,
+                    false
+            );
+        }
+
+        List<Long> messageIds = messages.stream()
+                .map(Message::getId)
+                .toList();
+
+        Map<Long, Long> unreadCountMap = chatPartRepository
+                .countUnreadMemberByMessages(chatRoomId, messageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatPartRepository.UnreadMemberCountProjection::getMessageId,
+                        ChatPartRepository.UnreadMemberCountProjection::getUnreadMemberCount
+                ));
+
+        List<ChatMessageResponseDTO.MessageSummary> messageSummaries =
+                messages.stream()
+                        .map(message ->
+                                ChatMessageConverter.toMessageSummary(
+                                        message,
+                                        currentUserId,
+                                        unreadCountMap
+                                )
+                        )
+                        .toList();
+
+        Long nextCursor = hasNext
+                ? messages.get(messages.size() - 1).getId()
+                : null;
+
+        return ChatMessageConverter.toListResponse(
+                chatRoom,
+                participantCount,
+                opponent,
+                teamRequest,
+                messageSummaries,
+                nextCursor,
+                hasNext
+        );
+    }
+
     private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(
             ChatPart myChatPart,
             Map<Long, Long> unreadCountMap,
@@ -260,5 +351,44 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         }
 
         return chatRoom.getLastMessage().getContent();
+    }
+
+    private ChatRoomResponseDTO.Opponent getOpponentOrNull(
+            ChatRoom chatRoom,
+            Long chatRoomId,
+            Long currentUserId
+    ) {
+        if (chatRoom.getChatType() != ChatType.DIRECT) {
+            return null;
+        }
+
+        ChatPart opponentChatPart = chatPartRepository
+                .findOpponent(chatRoomId, currentUserId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
+
+        return ChatMessageConverter.toOpponent(opponentChatPart);
+    }
+
+    private ChatMessageResponseDTO.TeamRequestInfo getTeamRequestOrNull(
+            ChatRoom chatRoom,
+            Long chatRoomId,
+            Long currentUserId
+    ) {
+        if (chatRoom.getChatType() != ChatType.DIRECT) {
+            return null;
+        }
+
+        return teamRequestRepository
+                .findLatestByChatRoomId(
+                        chatRoomId,
+                        PageRequest.of(0, 1)
+                )
+                .stream()
+                .findFirst()
+                .map(teamRequest -> ChatMessageConverter.toTeamRequestInfo(
+                        teamRequest,
+                        currentUserId
+                ))
+                .orElse(null);
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -89,23 +89,15 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     @Override
     public ChatRoomResponseDTO.ListResponse getMyChatRooms(
             Long currentUserId,
-            Long cursor
+            LocalDateTime cursorLastMessageAt,
+            Long cursorChatRoomId
     ) {
-        LocalDateTime cursorLastMessageAt = null;
-
-        if (cursor != null) {
-            ChatPart cursorChatPart = chatPartRepository
-                    .findByChatRoomIdAndUserId(cursor, currentUserId)
-                    .filter(chatPart -> !chatPart.isDeleted())
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_PARTICIPANT));
-
-            cursorLastMessageAt = cursorChatPart.getChatRoom().getLastMessageAt();
-        }
+        validateCursor(cursorLastMessageAt, cursorChatRoomId);
 
         List<ChatPart> chatParts = chatPartRepository.findMyChatRooms(
                 currentUserId,
-                cursor,
                 cursorLastMessageAt,
+                cursorChatRoomId,
                 PageRequest.of(0, ROOM_PAGE_SIZE + 1)
         );
 
@@ -183,8 +175,11 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 ))
                 .toList();
 
-        Long nextCursor = hasNext
-                ? chatRooms.get(chatRooms.size() - 1).chatRoomId()
+        ChatRoomResponseDTO.Cursor nextCursor = hasNext
+                ? new ChatRoomResponseDTO.Cursor(
+                chatRooms.get(chatRooms.size() - 1).lastMessageAt(),
+                chatRooms.get(chatRooms.size() - 1).chatRoomId()
+                )
                 : null;
 
         return new ChatRoomResponseDTO.ListResponse(
@@ -283,6 +278,15 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 nextCursor,
                 hasNext
         );
+    }
+
+    private void validateCursor(
+            LocalDateTime cursorLastMessageAt,
+            Long cursorChatRoomId
+    ) {
+        if ((cursorLastMessageAt == null) != (cursorChatRoomId == null)) {
+            throw new ChatException(ChatErrorCode.INVALID_CURSOR);
+        }
     }
 
     private ChatRoomResponseDTO.ChatRoomSummary toChatRoomSummary(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
-    private static final int PAGE_SIZE = 20;
+    private static final int PAGE_SIZE = 15;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatPartRepository chatPartRepository;

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -115,6 +115,16 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
             chatParts = chatParts.subList(0, PAGE_SIZE);
         }
 
+        // 조회 결과가 없으면, 배치 조회를 수행하지 않고 빈 응답 반환
+        if (chatParts.isEmpty()) {
+            return new ChatRoomResponseDTO.ListResponse(
+                    List.of(),
+                    null,
+                    false
+            );
+        }
+
+        // 배치 조회를 위한 채팅방 ID 목록 추출
         List<Long> chatRoomIds = chatParts.stream()
                 .map(chatPart -> chatPart.getChatRoom().getId())
                 .toList();
@@ -154,6 +164,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 )
         );
 
+        // 배치 조회 결과를 조합하여 채팅방 응답 DTO 생성
         List<ChatRoomResponseDTO.ChatRoomSummary> chatRooms = chatParts.stream()
                 .map(chatPart -> toChatRoomSummary(
                         chatPart,

--- a/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatBadgeType.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatBadgeType.java
@@ -1,0 +1,7 @@
+package com.capstone.pickIt.domain.chat.entity;
+
+public enum ChatBadgeType {
+    TEAM_REQUEST,
+    UNREAD_MESSAGE,
+    NONE
+}

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -71,12 +71,12 @@ public enum ChatErrorCode implements BaseCode {
     ),
     CANNOT_LEAVE_IN_PROGRESS_GROUP_CHAT(
             HttpStatus.BAD_REQUEST,
-            "CHAT400_X",
+            "CHAT400_13",
             "진행 중인 팀 채팅방은 나갈 수 없습니다."
     ),
     ALREADY_LEFT_CHAT_ROOM(
             HttpStatus.BAD_REQUEST,
-            "CHAT400_X",
+            "CHAT400_14",
             "이미 나간 채팅방입니다."
     ),
     NOT_CHAT_ROOM_PARTICIPANT(

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -71,12 +71,12 @@ public enum ChatErrorCode implements BaseCode {
     ),
     CANNOT_LEAVE_IN_PROGRESS_GROUP_CHAT(
             HttpStatus.BAD_REQUEST,
-            "CHAT400_13",
+            "CHAT400_X",
             "진행 중인 팀 채팅방은 나갈 수 없습니다."
     ),
     ALREADY_LEFT_CHAT_ROOM(
             HttpStatus.BAD_REQUEST,
-            "CHAT400_14",
+            "CHAT400_X",
             "이미 나간 채팅방입니다."
     ),
     NOT_CHAT_ROOM_PARTICIPANT(

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -69,6 +69,16 @@ public enum ChatErrorCode implements BaseCode {
             "CHAT400_12",
             "커서 값이 올바르지 않습니다."
     ),
+    CANNOT_LEAVE_IN_PROGRESS_GROUP_CHAT(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_13",
+            "진행 중인 팀 채팅방은 나갈 수 없습니다."
+    ),
+    ALREADY_LEFT_CHAT_ROOM(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_14",
+            "이미 나간 채팅방입니다."
+    ),
     NOT_CHAT_ROOM_PARTICIPANT(
             HttpStatus.FORBIDDEN,
             "CHAT403_1",

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -64,6 +64,11 @@ public enum ChatErrorCode implements BaseCode {
             "CHAT400_11",
             "팀원 요청에 필요한 포인트가 부족합니다."
     ),
+    INVALID_CURSOR(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_12",
+            "커서 값이 올바르지 않습니다."
+    ),
     NOT_CHAT_ROOM_PARTICIPANT(
             HttpStatus.FORBIDDEN,
             "CHAT403_1",

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -128,6 +128,11 @@ public enum ChatErrorCode implements BaseCode {
             HttpStatus.CONFLICT,
             "CHAT409_4",
             "현재 모집 가능한 상태가 아닙니다."
+    ),
+    ALREADY_JOINED_ACTIVE_TEAM(
+            HttpStatus.CONFLICT,
+            "CHAT409_5",
+            "이미 해당 과목의 모집 중이거나 진행 중인 팀에 참여 중입니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -1,9 +1,13 @@
 package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
@@ -29,4 +33,27 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
               AND cp.deletedAt IS NULL
             """)
     int countActiveParticipants(Long chatRoomId);
+
+    @Query("""
+        SELECT cp
+        FROM ChatPart cp
+        JOIN FETCH cp.chatRoom cr
+        LEFT JOIN FETCH cr.lastMessage lm
+        WHERE cp.user.id = :userId
+        AND cp.deletedAt IS NULL
+        AND (
+          :cursor IS NULL
+          OR cr.lastMessageAt < :cursorLastMessageAt
+          OR (cr.lastMessageAt = :cursorLastMessageAt AND cr.id < :cursor)
+        )
+        ORDER BY cr.lastMessageAt DESC, cr.id DESC
+    """)
+    List<ChatPart> findMyChatRooms(
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
+            @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            Pageable pageable
+    );
+
+    int countByChatRoomIdAndDeletedAtIsNull(Long chatRoomId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -8,7 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
     Optional<ChatPart> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
@@ -60,12 +62,6 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
         Long getParticipantCount();
     }
 
-    public interface OpponentProjection {
-        Long getChatRoomId();
-        Long getUserId();
-        String getNickname();
-    }
-
     @Query("""
         SELECT cp.chatRoom.id AS chatRoomId,
                COUNT(cp) AS participantCount
@@ -77,6 +73,12 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
     List<ParticipantCountProjection> countParticipantsByChatRoomIds(
             @Param("chatRoomIds") List<Long> chatRoomIds
     );
+
+    public interface OpponentProjection {
+        Long getChatRoomId();
+        Long getUserId();
+        String getNickname();
+    }
 
     @Query("""
         SELECT cp.chatRoom.id AS chatRoomId,
@@ -90,5 +92,30 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
     List<OpponentProjection> findOpponentsByChatRoomIds(
             @Param("chatRoomIds") List<Long> chatRoomIds,
             @Param("currentUserId") Long currentUserId
+    );
+
+    public interface UnreadMemberCountProjection {
+        Long getMessageId();
+        Long getUnreadMemberCount();
+    }
+
+    @Query("""
+        SELECT m.id AS messageId,
+                COUNT(cp) AS unreadMemberCount
+        FROM Message m
+        JOIN ChatPart cp
+        ON cp.chatRoom.id=m.chatRoom.id
+        WHERE m.chatRoom.id = :chatRoomId
+        AND m.id IN :messageIds
+        AND (
+            cp.lastReadMessage IS NULL
+            OR cp.lastReadMessage.id < m.id
+        )
+        AND cp.deletedAt IS NULL
+        GROUP BY m.id
+    """)
+    List<UnreadMemberCountProjection> countUnreadMemberByMessages(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("messageIds") List<Long> messageIds
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -46,32 +46,22 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
         WHERE cp.user.id = :userId
         AND cp.deletedAt IS NULL
         AND (
-          :cursorChatRoomId IS NULL
-          OR (
-              :cursorLastMessageAt IS NOT NULL
-              AND (
-                  cr.lastMessageAt < :cursorLastMessageAt
-                  OR (
-                      cr.lastMessageAt = :cursorLastMessageAt
-                      AND cr.id < :cursorChatRoomId
-                  )
-                  OR cr.lastMessageAt IS NULL
-              )
-          )
-          OR (
-              :cursorLastMessageAt IS NULL
-              AND cr.lastMessageAt IS NULL
-              AND cr.id < :cursorChatRoomId
-          )
+            :cursorChatRoomId IS NULL
+            OR (
+                COALESCE(cr.lastMessageAt, cr.createdAt) < :cursorSortAt
+                OR (
+                    COALESCE(cr.lastMessageAt, cr.createdAt) = :cursorSortAt
+                    AND cr.id < :cursorChatRoomId
+                )
+            )
         )
         ORDER BY
-            CASE WHEN cr.lastMessageAt IS NULL THEN 1 ELSE 0 END ASC,
-            cr.lastMessageAt DESC,
+            COALESCE(cr.lastMessageAt, cr.createdAt) DESC,
             cr.id DESC
     """)
     List<ChatPart> findMyChatRooms(
             @Param("userId") Long userId,
-            @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            @Param("cursorSortAt") LocalDateTime cursorSortAt,
             @Param("cursorChatRoomId") Long cursorChatRoomId,
             Pageable pageable
     );

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -44,16 +44,16 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
         WHERE cp.user.id = :userId
         AND cp.deletedAt IS NULL
         AND (
-          :cursor IS NULL
+          :cursorLastMessageAt IS NULL
           OR cr.lastMessageAt < :cursorLastMessageAt
-          OR (cr.lastMessageAt = :cursorLastMessageAt AND cr.id < :cursor)
+          OR (cr.lastMessageAt = :cursorLastMessageAt AND cr.id < :cursorChatRoomId)
         )
         ORDER BY cr.lastMessageAt DESC, cr.id DESC
     """)
     List<ChatPart> findMyChatRooms(
             @Param("userId") Long userId,
-            @Param("cursor") Long cursor,
             @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
+            @Param("cursorChatRoomId") Long cursorChatRoomId,
             Pageable pageable
     );
 

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -55,5 +55,40 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             Pageable pageable
     );
 
-    int countByChatRoomIdAndDeletedAtIsNull(Long chatRoomId);
+    public interface ParticipantCountProjection {
+        Long getChatRoomId();
+        Long getParticipantCount();
+    }
+
+    public interface OpponentProjection {
+        Long getChatRoomId();
+        Long getUserId();
+        String getNickname();
+    }
+
+    @Query("""
+        SELECT cp.chatRoom.id AS chatRoomId,
+               COUNT(cp) AS participantCount
+        FROM ChatPart cp
+        WHERE cp.chatRoom.id IN :chatRoomIds
+        AND cp.deletedAt IS NULL
+        GROUP BY cp.chatRoom.id
+    """)
+    List<ParticipantCountProjection> countParticipantsByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds
+    );
+
+    @Query("""
+        SELECT cp.chatRoom.id AS chatRoomId,
+               cp.user.id AS userId,
+               cp.user.nickname AS nickname
+        FROM ChatPart cp
+        WHERE cp.chatRoom.id IN :chatRoomIds
+        AND cp.user.id <> :currentUserId
+        AND cp.deletedAt IS NULL
+    """)
+    List<OpponentProjection> findOpponentsByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -1,8 +1,10 @@
 package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -72,6 +74,20 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             @Param("cursorLastMessageAt") LocalDateTime cursorLastMessageAt,
             @Param("cursorChatRoomId") Long cursorChatRoomId,
             Pageable pageable
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT cp
+        FROM ChatPart cp
+        JOIN FETCH cp.chatRoom cr
+        LEFT JOIN FETCH cr.projectTeam
+        WHERE cr.id = :chatRoomId
+          AND cp.user.id = :userId
+        """)
+    Optional<ChatPart> findByChatRoomIdAndUserIdWithLock(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("userId") Long userId
     );
 
     public interface ParticipantCountProjection {

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -44,11 +44,28 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
         WHERE cp.user.id = :userId
         AND cp.deletedAt IS NULL
         AND (
-          :cursorLastMessageAt IS NULL
-          OR cr.lastMessageAt < :cursorLastMessageAt
-          OR (cr.lastMessageAt = :cursorLastMessageAt AND cr.id < :cursorChatRoomId)
+          :cursorChatRoomId IS NULL
+          OR (
+              :cursorLastMessageAt IS NOT NULL
+              AND (
+                  cr.lastMessageAt < :cursorLastMessageAt
+                  OR (
+                      cr.lastMessageAt = :cursorLastMessageAt
+                      AND cr.id < :cursorChatRoomId
+                  )
+                  OR cr.lastMessageAt IS NULL
+              )
+          )
+          OR (
+              :cursorLastMessageAt IS NULL
+              AND cr.lastMessageAt IS NULL
+              AND cr.id < :cursorChatRoomId
+          )
         )
-        ORDER BY cr.lastMessageAt DESC, cr.id DESC
+        ORDER BY
+            CASE WHEN cr.lastMessageAt IS NULL THEN 1 ELSE 0 END ASC,
+            cr.lastMessageAt DESC,
+            cr.id DESC
     """)
     List<ChatPart> findMyChatRooms(
             @Param("userId") Long userId,

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -2,6 +2,24 @@ package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    @Query("""
+        SELECT COUNT(m)
+        FROM Message m
+        WHERE m.chatRoom.id = :chatRoomId
+        AND m.sender.id <> :currentUserId
+        AND (
+          :lastReadMessageId IS NULL
+          OR m.id > :lastReadMessageId
+        )
+    """)
+    long countUnreadMessages(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("currentUserId") Long currentUserId,
+            @Param("lastReadMessageId") Long lastReadMessageId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.chat.repository;
 
 import com.capstone.pickIt.domain.chat.entity.Message;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,5 +33,22 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<UnreadCountProjection> countUnreadMessagesByChatRoomIds(
             @Param("chatRoomIds") List<Long> chatRoomIds,
             @Param("currentUserId") Long currentUserId
+    );
+
+    @Query("""
+        SELECT m
+        FROM Message m
+        JOIN FETCH m.user
+        WHERE m.chatRoom.id=:chatRoomId
+        AND (
+            :cursor IS NULL
+            OR m.id < :cursor
+        )
+        ORDER BY m.id DESC
+    """)
+    List<Message> findMessages(
+            Long chatRoomId,
+            Long cursor,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -23,6 +23,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         ON cp.chatRoom.id = m.chatRoom.id
         AND cp.user.id = :currentUserId
         WHERE m.chatRoom.id IN :chatRoomIds
+        AND cp.deletedAt IS NULL
         AND m.user.id <> :currentUserId
         AND (
             cp.lastReadMessage IS NULL

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -5,21 +5,32 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+    public interface UnreadCountProjection {
+        Long getChatRoomId();
+        Long getUnreadCount();
+    }
+
     @Query("""
-        SELECT COUNT(m)
+        SELECT m.chatRoom.id AS chatRoomId,
+               COUNT(m) AS unreadCount
         FROM Message m
-        WHERE m.chatRoom.id = :chatRoomId
+        JOIN ChatPart cp
+        ON cp.chatRoom.id = m.chatRoom.id
+        AND cp.user.id = :currentUserId
+        WHERE m.chatRoom.id IN :chatRoomIds
         AND m.user.id <> :currentUserId
         AND (
-          :lastReadMessageId IS NULL
-          OR m.id > :lastReadMessageId
+            cp.lastReadMessage IS NULL
+            OR m.id > cp.lastReadMessage.id
         )
+        GROUP BY m.chatRoom.id
     """)
-    long countUnreadMessages(
-            @Param("chatRoomId") Long chatRoomId,
-            @Param("currentUserId") Long currentUserId,
-            @Param("lastReadMessageId") Long lastReadMessageId
+    List<UnreadCountProjection> countUnreadMessagesByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -11,7 +11,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         SELECT COUNT(m)
         FROM Message m
         WHERE m.chatRoom.id = :chatRoomId
-        AND m.sender.id <> :currentUserId
+        AND m.user.id <> :currentUserId
         AND (
           :lastReadMessageId IS NULL
           OR m.id > :lastReadMessageId

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -48,8 +48,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
         ORDER BY m.id DESC
     """)
     List<Message> findMessages(
-            Long chatRoomId,
-            Long cursor,
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("cursor") Long cursor,
             Pageable pageable
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
@@ -1,11 +1,19 @@
 package com.capstone.pickIt.domain.course.repository;
 
 import com.capstone.pickIt.domain.course.entity.Course;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
     Optional<Course> findByCourseNameAndSemester(String courseName, String semester);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Course c WHERE c.id = :courseId")
+    Optional<Course> findByIdForUpdate(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/CourseRepository.java
@@ -15,5 +15,5 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM Course c WHERE c.id = :courseId")
-    Optional<Course> findByIdForUpdate(@Param("courseId") Long courseId);
+    Optional<Course> findByIdWithLock(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequestRole.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamRequestRole.java
@@ -1,0 +1,6 @@
+package com.capstone.pickIt.domain.project.entity;
+
+public enum TeamRequestRole {
+    SENDER,
+    RECEIVER
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.ProjectTeamMember;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,20 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
 
     boolean existsByProjectTeamIdAndUserId(Long projectTeamId, Long userId);
 
+    @Query("""
+        SELECT COUNT(ptm) > 0
+        FROM ProjectTeamMember ptm
+        JOIN ptm.projectTeam pt
+        WHERE pt.course.id = :courseId
+        AND ptm.user.id = :userId
+        AND ptm.leftAt IS NULL
+        AND pt.status IN :statuses
+    """)
+    boolean existsActiveTeamByCourseAndUser(
+            @Param("courseId") Long courseId,
+            @Param("userId") Long userId,
+            @Param("statuses") List<ProjectTeamStatus> statuses
+    );
 
     List<ProjectTeamMember> findAllByUserIdAndRecruitmentConfirmStatusAndLeftAtIsNullOrderByJoinedAtDesc(
             Long userId,

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> {
@@ -33,13 +34,20 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             Pageable pageable
     );
 
-    boolean existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
-            Long chatRoomId,
-            Long receiverId,
-            TeamRequestStatus teamRequestStatus
-    );
-
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT tr FROM TeamRequest tr WHERE tr.id = :teamRequestId")
     Optional<TeamRequest> findByIdWithLock(@Param("teamRequestId") Long teamRequestId);
+
+    @Query("""
+        SELECT tr.chatRoom.id
+        FROM TeamRequest tr
+        WHERE tr.chatRoom.id IN :chatRoomIds
+        AND tr.receiver.id = :currentUserId
+        AND tr.teamRequestStatus = :status
+    """)
+    List<Long> findPendingRequestChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("currentUserId") Long currentUserId,
+            @Param("status") TeamRequestStatus status
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -2,11 +2,16 @@ package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.TeamRequest;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> {
 
@@ -33,4 +38,8 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             Long receiverId,
             TeamRequestStatus teamRequestStatus
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT tr FROM TeamRequest tr WHERE tr.id = :teamRequestId")
+    Optional<TeamRequest> findByIdWithLock(@Param("teamRequestId") Long teamRequestId);
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -27,4 +27,10 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             LocalDateTime createdAt,
             Pageable pageable
     );
+
+    boolean existsByChatRoomIdAndReceiverIdAndTeamRequestStatus(
+            Long chatRoomId,
+            Long receiverId,
+            TeamRequestStatus teamRequestStatus
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -50,4 +50,17 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             @Param("currentUserId") Long currentUserId,
             @Param("status") TeamRequestStatus status
     );
+
+    @Query("""
+        SELECT tr
+        FROM TeamRequest tr
+        JOIN FETCH tr.sender
+        JOIN FETCH tr.receiver
+        WHERE tr.chatRoom.id = :chatRoomId
+        ORDER BY tr.createdAt DESC
+    """)
+    List<TeamRequest> findLatestByChatRoomId(
+            @Param("chatRoomId") Long chatRoomId,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #115 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

채팅방 나가기 API 구현 (`PATCH /api/chats/{chatRoomId}/leave`)
- 현재 사용자의 채팅방 참여 여부 및 이미 나간 상태인지 검증
- 소프트 삭제 처리
  - 채팅방 나가기 시 `chat_part.deleted_at` 갱신
  - 채팅방 및 메시지 데이터는 유지하고, 사용자 참여 정보만 나간 상태로 변경
- DIRECT 채팅방은 언제든 나가기 가능하도록 구현
- GROUP 채팅방은 `project_team.status` 기반 나가기 가능 여부 검증
  - `IN_PROGRESS` 상태에서는 나가기 불가
  - `DONE` 상태에서는 나가기 가능

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1552" height="998" alt="채팅방 나가기" src="https://github.com/user-attachments/assets/5f1686a8-c6d4-4b25-946a-d4344e7708d9" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅방 목록 조회 기능 추가
  * 채팅방 메시지 목록 조회 기능 추가
  * 채팅방 나가기 기능 추가
  * 커서 기반 페이지네이션으로 대량 데이터 효율적 조회 지원
  * 채팅방 배지 표시(미읽음 메시지/팀 요청) 기능 추가

* **개선사항**
  * 채팅 관련 새로운 응답 코드 3종 추가(CHAT200_5, CHAT200_6, CHAT200_7)
  * 중복 팀 참여 검증 로직 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->