### PR TITLE
[Feat] 팀 프로젝트 목록 조회 구현 

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/project/controller/ProjectController.java
+++ b/src/main/java/com/capstone/pickIt/api/project/controller/ProjectController.java
@@ -1,14 +1,24 @@
 package com.capstone.pickIt.api.project.controller;
 
 import com.capstone.pickIt.api.project.dto.response.ProjectDetailResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.ProjectListItemResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberListResponseDTO;
 import com.capstone.pickIt.api.project.service.ProjectService;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
 import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Project", description = "프로젝트 워크스페이스 API")
 @RestController
@@ -17,6 +27,91 @@ import org.springframework.web.bind.annotation.*;
 public class ProjectController {
 
     private final ProjectService projectService;
+
+    @Operation(
+            summary = "내 팀플 목록 조회",
+            description = """
+                    로그인한 사용자가 참여 중인 팀 프로젝트 목록을 조회합니다.
+
+                    **status 파라미터로 탭별 필터링 가능:**
+                    - `RECRUITING` : 모집중인 팀 (아직 팀원을 구하는 중)
+                    - `IN_PROGRESS` : 진행중인 팀 (팀 구성 완료, 프로젝트 진행 중)
+                    - `DONE` : 완료된 팀
+                    - 파라미터 없이 요청 시 → 전체 목록 반환
+
+                    **조회 조건:**
+                    - 탈퇴(leftAt != null)한 팀은 제외됩니다.
+                    - 가입 승인(CONFIRMED) 상태인 팀만 조회됩니다.
+                    - 가입 신청 대기(PENDING) 또는 거절(REJECTED) 상태는 포함되지 않습니다.
+                    - 최신 참여순(joinedAt DESC)으로 정렬됩니다.
+
+                    **인증 필요:** `Authorization: Bearer {ACCESS_TOKEN}` 헤더 필수
+                    """,
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON200",
+                                      "message": "성공입니다.",
+                                      "result": [
+                                        {
+                                          "projectId": 1,
+                                          "projectName": "PickIT",
+                                          "courseName": "캡스톤디자인",
+                                          "memberCount": 4,
+                                          "currentMembers": 4,
+                                          "projectStatus": "IN_PROGRESS"
+                                        },
+                                        {
+                                          "projectId": 2,
+                                          "projectName": "CloudMate",
+                                          "courseName": "클라우드컴퓨팅",
+                                          "memberCount": 5,
+                                          "currentMembers": 3,
+                                          "projectStatus": "RECRUITING"
+                                        }
+                                      ]
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 로그인이 필요하거나 토큰이 만료된 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    @GetMapping
+    public ApiResponse<List<ProjectListItemResponseDTO>> getUserProjectList(
+            @Parameter(
+                    description = "프로젝트 상태 필터 (생략 시 전체 조회)",
+                    schema = @Schema(allowableValues = {"RECRUITING", "IN_PROGRESS", "DONE"}),
+                    example = "IN_PROGRESS"
+            )
+            @RequestParam(required = false) ProjectTeamStatus status
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.OK,
+                projectService.getUserProjectList(status)
+        );
+    }
 
     @Operation(
             summary = "프로젝트 상세 조회",

--- a/src/main/java/com/capstone/pickIt/api/project/controller/ProjectController.java
+++ b/src/main/java/com/capstone/pickIt/api/project/controller/ProjectController.java
@@ -63,19 +63,19 @@ public class ProjectController {
                                       "result": [
                                         {
                                           "projectId": 1,
-                                          "projectName": "PickIT",
+                                          "projectName": "캡스톤디자인",
                                           "courseName": "캡스톤디자인",
-                                          "memberCount": 4,
                                           "currentMembers": 4,
-                                          "projectStatus": "IN_PROGRESS"
+                                          "projectStatus": "IN_PROGRESS",
+                                          "memberNames": ["김철수", "이영희", "박민준", "최수진"]
                                         },
                                         {
                                           "projectId": 2,
-                                          "projectName": "CloudMate",
+                                          "projectName": "클라우드컴퓨팅",
                                           "courseName": "클라우드컴퓨팅",
-                                          "memberCount": 5,
                                           "currentMembers": 3,
-                                          "projectStatus": "RECRUITING"
+                                          "projectStatus": "RECRUITING",
+                                          "memberNames": ["홍길동", "김영수", "이지은"]
                                         }
                                       ]
                                     }

--- a/src/main/java/com/capstone/pickIt/api/project/converter/ProjectConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/project/converter/ProjectConverter.java
@@ -2,6 +2,7 @@ package com.capstone.pickIt.api.project.converter;
 
 import com.capstone.pickIt.api.checklists.dto.response.ChecklistItemResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectDetailResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.ProjectListItemResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberListResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberSummaryDTO;
 import com.capstone.pickIt.domain.point.entity.Point;
@@ -40,6 +41,22 @@ public class ProjectConverter {
             List<ProjectMemberSummaryDTO> members
     ) {
         return new ProjectMemberListResponseDTO(projectTeamId, members);
+    }
+
+    public static ProjectListItemResponseDTO toListItem(ProjectTeam projectTeam, List<String> memberNames) {
+        String projectName = projectTeam.getName() != null
+                ? projectTeam.getName()
+                : projectTeam.getCourse().getCourseName();
+        int memberCount = memberNames.size();
+        return new ProjectListItemResponseDTO(
+                projectTeam.getId(),
+                projectName,
+                projectTeam.getCourse().getCourseName(),
+                memberCount,
+                memberCount,
+                projectTeam.getStatus(),
+                memberNames
+        );
     }
 
     public static ProjectMemberSummaryDTO toMemberSummary(

--- a/src/main/java/com/capstone/pickIt/api/project/converter/ProjectConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/project/converter/ProjectConverter.java
@@ -47,13 +47,11 @@ public class ProjectConverter {
         String projectName = projectTeam.getName() != null
                 ? projectTeam.getName()
                 : projectTeam.getCourse().getCourseName();
-        int memberCount = memberNames.size();
         return new ProjectListItemResponseDTO(
                 projectTeam.getId(),
                 projectName,
                 projectTeam.getCourse().getCourseName(),
-                memberCount,
-                memberCount,
+                memberNames.size(),
                 projectTeam.getStatus(),
                 memberNames
         );

--- a/src/main/java/com/capstone/pickIt/api/project/dto/response/ProjectListItemResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/project/dto/response/ProjectListItemResponseDTO.java
@@ -8,7 +8,6 @@ public record ProjectListItemResponseDTO(
         Long projectId,
         String projectName,
         String courseName,
-        int memberCount,
         int currentMembers,
         ProjectTeamStatus projectStatus,
         List<String> memberNames

--- a/src/main/java/com/capstone/pickIt/api/project/dto/response/ProjectListItemResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/project/dto/response/ProjectListItemResponseDTO.java
@@ -1,0 +1,15 @@
+package com.capstone.pickIt.api.project.dto.response;
+
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
+
+import java.util.List;
+
+public record ProjectListItemResponseDTO(
+        Long projectId,
+        String projectName,
+        String courseName,
+        int memberCount,
+        int currentMembers,
+        ProjectTeamStatus projectStatus,
+        List<String> memberNames
+) {}

--- a/src/main/java/com/capstone/pickIt/api/project/service/ProjectService.java
+++ b/src/main/java/com/capstone/pickIt/api/project/service/ProjectService.java
@@ -1,11 +1,17 @@
 package com.capstone.pickIt.api.project.service;
 
 import com.capstone.pickIt.api.project.dto.response.ProjectDetailResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.ProjectListItemResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberListResponseDTO;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
+
+import java.util.List;
 
 public interface ProjectService {
 
     ProjectDetailResponseDTO getProjectDetail(Long projectTeamId);
 
     ProjectMemberListResponseDTO getProjectMembers(Long projectTeamId);
+
+    List<ProjectListItemResponseDTO> getUserProjectList(ProjectTeamStatus status);
 }

--- a/src/main/java/com/capstone/pickIt/api/project/service/ProjectServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/project/service/ProjectServiceImpl.java
@@ -4,12 +4,14 @@ import com.capstone.pickIt.api.checklists.converter.ChecklistConverter;
 import com.capstone.pickIt.api.checklists.dto.response.ChecklistItemResponseDTO;
 import com.capstone.pickIt.api.project.converter.ProjectConverter;
 import com.capstone.pickIt.api.project.dto.response.ProjectDetailResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.ProjectListItemResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberListResponseDTO;
 import com.capstone.pickIt.api.project.dto.response.ProjectMemberSummaryDTO;
 import com.capstone.pickIt.domain.point.entity.Point;
 import com.capstone.pickIt.domain.point.repository.PointRepository;
 import com.capstone.pickIt.domain.project.entity.ProjectTeam;
 import com.capstone.pickIt.domain.project.entity.ProjectTeamMember;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus;
 import com.capstone.pickIt.domain.project.exception.ProjectErrorCode;
 import com.capstone.pickIt.domain.project.exception.ProjectException;
@@ -85,6 +87,38 @@ public class ProjectServiceImpl implements ProjectService {
 
         return members.stream()
                 .map(member -> ProjectConverter.toMemberSummary(member, pointMap))
+                .toList();
+    }
+
+    @Override
+    public List<ProjectListItemResponseDTO> getUserProjectList(ProjectTeamStatus status) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
+        List<ProjectTeamMember> memberships = projectTeamMemberRepository
+                .findActiveConfirmedMembershipsWithTeamAndCourse(currentUserId, status);
+
+        if (memberships.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> projectTeamIds = memberships.stream()
+                .map(m -> m.getProjectTeam().getId())
+                .toList();
+
+        Map<Long, List<String>> memberNamesMap = projectTeamMemberRepository
+                .findActiveConfirmedMembersWithUserByProjectTeamIds(projectTeamIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        m -> m.getProjectTeam().getId(),
+                        Collectors.mapping(m -> m.getUser().getNickname(), Collectors.toList())
+                ));
+
+        return memberships.stream()
+                .map(m -> {
+                    ProjectTeam team = m.getProjectTeam();
+                    List<String> names = memberNamesMap.getOrDefault(team.getId(), List.of());
+                    return ProjectConverter.toListItem(team, names);
+                })
                 .toList();
     }
 

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
@@ -33,6 +33,9 @@ public class ProjectTeam extends BaseEntity {
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 
+    @Column(name = "name", length = 100)
+    private String name;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private ProjectTeamStatus status;
@@ -75,6 +78,7 @@ public class ProjectTeam extends BaseEntity {
     public static ProjectTeam createRecruitingTeam(Course course) {
         return ProjectTeam.builder()
                 .course(course)
+                .name(course.getCourseName())
                 .status(ProjectTeamStatus.RECRUITING)
                 .build();
     }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -87,14 +87,15 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
     );
 
     @Query("""
-        SELECT ptm.projectTeam.id, COUNT(ptm)
+        SELECT ptm
         FROM ProjectTeamMember ptm
+        JOIN FETCH ptm.user
         WHERE ptm.projectTeam.id IN :projectTeamIds
           AND ptm.leftAt IS NULL
           AND ptm.recruitmentConfirmStatus = 'CONFIRMED'
-        GROUP BY ptm.projectTeam.id
+        ORDER BY ptm.projectTeam.id, ptm.joinedAt ASC
     """)
-    List<Object[]> countActiveConfirmedMembersByProjectTeamIds(
+    List<ProjectTeamMember> findActiveConfirmedMembersWithUserByProjectTeamIds(
             @Param("projectTeamIds") List<Long> projectTeamIds
     );
 }

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.domain.project.repository;
 
 import com.capstone.pickIt.domain.project.entity.ProjectTeamMember;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -67,5 +68,33 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
     List<ProjectTeamMember> findActiveConfirmedMembersWithUser(
             @Param("projectTeamId") Long projectTeamId,
             @Param("status") RecruitmentConfirmStatus status
+    );
+
+    @Query("""
+        SELECT ptm
+        FROM ProjectTeamMember ptm
+        JOIN FETCH ptm.projectTeam pt
+        JOIN FETCH pt.course
+        WHERE ptm.user.id = :userId
+          AND ptm.recruitmentConfirmStatus = 'CONFIRMED'
+          AND ptm.leftAt IS NULL
+          AND (:status IS NULL OR pt.status = :status)
+        ORDER BY ptm.joinedAt DESC
+    """)
+    List<ProjectTeamMember> findActiveConfirmedMembershipsWithTeamAndCourse(
+            @Param("userId") Long userId,
+            @Param("status") ProjectTeamStatus status
+    );
+
+    @Query("""
+        SELECT ptm.projectTeam.id, COUNT(ptm)
+        FROM ProjectTeamMember ptm
+        WHERE ptm.projectTeam.id IN :projectTeamIds
+          AND ptm.leftAt IS NULL
+          AND ptm.recruitmentConfirmStatus = 'CONFIRMED'
+        GROUP BY ptm.projectTeam.id
+    """)
+    List<Object[]> countActiveConfirmedMembersByProjectTeamIds(
+            @Param("projectTeamIds") List<Long> projectTeamIds
     );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #102 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  사용자가 참여 중인 팀 프로젝트 목록 조회 API 구현
                                          
  - GET /projects 엔드포인트 추가
  - status 쿼리 파라미터로 상태별 필터링 지원 (RECRUITING / IN_PROGRESS / DONE / 생략 시 전체)                                                                                                  - 탈퇴한 팀(leftAt IS NOT NULL) 및 미승인(PENDING, REJECTED) 멤버십 제외
  - 최신 참여순(joinedAt DESC) 정렬                                                                                                                                                           
  - 팀 멤버 닉네임 목록 포함 반환 (N+1 없이 배치 조회)



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="660" height="323" alt="image" src="https://github.com/user-attachments/assets/a5a23933-9761-4e1b-9b1d-528a9b15c4d4" />

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자의 팀 프로젝트 목록 조회 기능 추가: 프로젝트 상태별 필터링을 지원하며, 각 프로젝트의 팀 구성원 수, 현재 참여자 수, 팀원 이름 등의 상세 정보를 함께 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->