### PR TITLE
[Feat] 파일 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // Google Cloud Storage (파일 업로드)
+    implementation 'com.google.cloud:google-cloud-storage'
+
     // Test (표준)
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // Google Cloud Storage (파일 업로드)
-    implementation 'com.google.cloud:google-cloud-storage'
+    implementation 'com.google.cloud:google-cloud-storage:2.48.2'
 
     // Test (표준)
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/code/ChatSuccessCode.java
@@ -48,6 +48,11 @@ public enum ChatSuccessCode implements BaseCode {
             HttpStatus.OK,
             "CHAT200_8",
             "메시지 읽음 처리에 성공했습니다."
+    ),
+    CHAT_FILES_UPLOADED(
+            HttpStatus.OK,
+            "CHAT_FILES_UPLOADED",
+            "채팅 파일 업로드에 성공했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -5,6 +5,7 @@ import com.capstone.pickIt.api.chat.dto.request.ChatMessageRequestDTO;
 import com.capstone.pickIt.api.chat.dto.request.DirectChatRoomCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.request.TeamRequestCreateRequestDTO;
 import com.capstone.pickIt.api.chat.dto.response.*;
+import com.capstone.pickIt.api.chat.service.ChatFileService;
 import com.capstone.pickIt.api.chat.service.ChatRoomCommandService;
 import com.capstone.pickIt.api.chat.service.ChatRoomQueryService;
 import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
@@ -13,9 +14,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Tag(name = "Chat", description = "채팅 API")
 @RestController
@@ -25,6 +29,7 @@ public class ChatRoomController {
 
     private final ChatRoomCommandService chatRoomCommandService;
     private final ChatRoomQueryService chatRoomQueryService;
+    private final ChatFileService chatFileService;
 
     @Operation(summary = "1:1 채팅방 생성/재입장", description = "상대 사용자와의 1:1 채팅방을 생성하거나, 기존 채팅방이 존재하면 재사용 및 재입장 처리합니다.")
     @PostMapping
@@ -121,6 +126,23 @@ public class ChatRoomController {
                         chatRoomId,
                         request
                 )
+        );
+    }
+
+    @Operation(
+            summary = "채팅 파일 업로드",
+            description = "채팅 메시지에 첨부할 파일을 Google Cloud Storage에 업로드하고, 파일 URL 목록을 반환합니다."
+    )
+    @PostMapping(
+            value = "/files",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ApiResponse<FileResponseDTO.UploadResponse> uploadChatFiles(
+            @RequestPart("files") List<MultipartFile> files
+    ) {
+        return ApiResponse.onSuccess(
+                ChatSuccessCode.CHAT_FILES_UPLOADED,
+                chatFileService.uploadFiles(files)
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/controller/ChatRoomController.java
@@ -140,9 +140,14 @@ public class ChatRoomController {
     public ApiResponse<FileResponseDTO.UploadResponse> uploadChatFiles(
             @RequestPart("files") List<MultipartFile> files
     ) {
+        Long currentUserId = SecurityUtil.requireUserId();
+
         return ApiResponse.onSuccess(
                 ChatSuccessCode.CHAT_FILES_UPLOADED,
-                chatFileService.uploadFiles(files)
+                chatFileService.uploadFiles(
+                        currentUserId,
+                        files
+                )
         );
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/converter/ChatMessageConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/ChatMessageConverter.java
@@ -5,6 +5,7 @@ import com.capstone.pickIt.api.chat.dto.response.ChatRoomResponseDTO;
 import com.capstone.pickIt.domain.chat.entity.ChatPart;
 import com.capstone.pickIt.domain.chat.entity.ChatRoom;
 import com.capstone.pickIt.domain.chat.entity.Message;
+import com.capstone.pickIt.domain.chat.entity.MessageFile;
 import com.capstone.pickIt.domain.project.entity.TeamRequest;
 import com.capstone.pickIt.domain.project.entity.TeamRequestRole;
 
@@ -38,7 +39,8 @@ public class ChatMessageConverter {
     public static ChatMessageResponseDTO.MessageSummary toMessageSummary(
             Message message,
             Long currentUserId,
-            Map<Long, Long> unreadCountMap
+            Map<Long, Long> unreadCountMap,
+            Map<Long, List<MessageFile>> fileMap
     ) {
         return new ChatMessageResponseDTO.MessageSummary(
                 message.getId(),
@@ -48,7 +50,16 @@ public class ChatMessageConverter {
                 ),
                 message.getMessageType(),
                 message.getContent(),
-                List.of(),
+                fileMap.getOrDefault(message.getId(), List.of())
+                        .stream()
+                        .map(file -> new ChatMessageResponseDTO.FileInfo(
+                                file.getId(),
+                                file.getFileName(),
+                                file.getFileUrl(),
+                                file.getFileSize(),
+                                file.getContentType()
+                        ))
+                        .toList(),
                 message.getCreatedAt(),
                 message.getUser().getId().equals(currentUserId),
                 unreadCountMap.getOrDefault(message.getId(), 0L)

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/FileResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/FileResponseDTO.java
@@ -12,8 +12,8 @@ public class FileResponseDTO {
     public record FileInfo(
             String fileName,
             String fileUrl,
-            String contentType,
-            Long size
+            Long fileSize,
+            String contentType
     ) {
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/FileResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/FileResponseDTO.java
@@ -1,0 +1,19 @@
+package com.capstone.pickIt.api.chat.dto.response;
+
+import java.util.List;
+
+public class FileResponseDTO {
+
+    public record UploadResponse(
+            List<FileInfo> files
+    ) {
+    }
+
+    public record FileInfo(
+            String fileName,
+            String fileUrl,
+            String contentType,
+            Long size
+    ) {
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileService.java
@@ -1,0 +1,13 @@
+package com.capstone.pickIt.api.chat.service;
+
+import com.capstone.pickIt.api.chat.dto.response.FileResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ChatFileService {
+
+    FileResponseDTO.UploadResponse uploadFiles(
+            List<MultipartFile> files
+    );
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileService.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileService.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface ChatFileService {
 
     FileResponseDTO.UploadResponse uploadFiles(
+            Long currentUserId,
             List<MultipartFile> files
     );
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
@@ -44,16 +44,13 @@ public class ChatFileServiceImpl implements ChatFileService {
 
             return new FileResponseDTO.UploadResponse(uploadedFiles);
 
+        } catch (ChatException e) {
+            rollbackUploadedFiles(uploadedObjectNames);
+            throw e;
+
         } catch (Exception e) {
             log.error("GCS 파일 업로드 실패", e);
-
-            uploadedObjectNames.forEach(objectName -> {
-                try {
-                    storage.delete(bucketName, objectName);
-                } catch (Exception ignored) {
-                }
-            });
-
+            rollbackUploadedFiles(uploadedObjectNames);
             throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
         }
     }
@@ -112,5 +109,15 @@ public class ChatFileServiceImpl implements ChatFileService {
                 + bucketName
                 + "/"
                 + storedFileName;
+    }
+
+    private void rollbackUploadedFiles(List<String> uploadedObjectNames) {
+        uploadedObjectNames.forEach(objectName -> {
+            try {
+                storage.delete(bucketName, objectName);
+            } catch (Exception cleanupEx) {
+                log.warn("업로드 롤백 삭제 실패: objectName={}", objectName, cleanupEx);
+            }
+        });
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
@@ -42,9 +42,11 @@ public class ChatFileServiceImpl implements ChatFileService {
             return new FileResponseDTO.UploadResponse(uploadedFiles);
 
         } catch (Exception e) {
-            uploadedObjectNames.forEach(objectName ->
-                    storage.delete(bucketName, objectName)
-            );
+            uploadedObjectNames.forEach(objectName -> {
+                try {
+                    storage.delete(bucketName, objectName);
+                } catch (Exception ignored) {}
+            });
 
             throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
         }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
@@ -14,12 +14,33 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatFileServiceImpl implements ChatFileService {
+
+    private static final long MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+    private static final int MAX_FILE_COUNT = 5;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            // images
+            "image/png",
+            "image/jpeg",
+            "image/webp",
+            "image/gif",
+
+            // documents
+            "application/pdf",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "text/plain"
+    );
 
     @Value("${gcp.storage.bucket}")
     private String bucketName;
@@ -33,6 +54,10 @@ public class ChatFileServiceImpl implements ChatFileService {
     ) {
         if (files == null || files.isEmpty()) {
             throw new ChatException(ChatErrorCode.MESSAGE_FILE_REQUIRED);
+        }
+
+        if (files.size() > MAX_FILE_COUNT) {
+            throw new ChatException(ChatErrorCode.FILE_COUNT_EXCEEDED);
         }
 
         List<String> uploadedObjectNames = new ArrayList<>();
@@ -60,9 +85,7 @@ public class ChatFileServiceImpl implements ChatFileService {
             MultipartFile file,
             List<String> uploadedObjectNames
     ) {
-        if (file.isEmpty()) {
-            throw new ChatException(ChatErrorCode.MESSAGE_FILE_REQUIRED);
-        }
+        validateFile(file);
 
         String originalFileName = file.getOriginalFilename();
         String extension = getExtension(originalFileName);
@@ -93,6 +116,20 @@ public class ChatFileServiceImpl implements ChatFileService {
 
         } catch (IOException e) {
             throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_FILE_REQUIRED);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new ChatException(ChatErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            throw new ChatException(ChatErrorCode.INVALID_FILE_TYPE);
         }
     }
 

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
@@ -1,0 +1,107 @@
+package com.capstone.pickIt.api.chat.service;
+
+import com.capstone.pickIt.api.chat.dto.response.FileResponseDTO;
+import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
+import com.capstone.pickIt.domain.chat.exception.ChatException;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatFileServiceImpl implements ChatFileService {
+
+    @Value("${gcp.storage.bucket}")
+    private String bucketName;
+
+    private final Storage storage;
+
+    @Override
+    public FileResponseDTO.UploadResponse uploadFiles(
+            List<MultipartFile> files
+    ) {
+        if (files == null || files.isEmpty()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_FILE_REQUIRED);
+        }
+
+        List<String> uploadedObjectNames = new ArrayList<>();
+
+        try {
+            List<FileResponseDTO.FileInfo> uploadedFiles = files.stream()
+                    .map(file -> uploadSingleFile(file, uploadedObjectNames))
+                    .toList();
+
+            return new FileResponseDTO.UploadResponse(uploadedFiles);
+
+        } catch (Exception e) {
+            uploadedObjectNames.forEach(objectName ->
+                    storage.delete(bucketName, objectName)
+            );
+
+            throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private FileResponseDTO.FileInfo uploadSingleFile(
+            MultipartFile file,
+            List<String> uploadedObjectNames
+    ) {
+        if (file.isEmpty()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_FILE_REQUIRED);
+        }
+
+        String originalFileName = file.getOriginalFilename();
+        String extension = getExtension(originalFileName);
+        String storedFileName = "chat/" + UUID.randomUUID() + extension;
+
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                            bucketName,
+                            storedFileName
+                    )
+                    .setContentType(file.getContentType())
+                    .build();
+
+            storage.create(
+                    blobInfo,
+                    file.getBytes(),
+                    Storage.BlobTargetOption.doesNotExist()
+            );
+
+            uploadedObjectNames.add(storedFileName);
+
+            return new FileResponseDTO.FileInfo(
+                    originalFileName,
+                    getFileUrl(storedFileName),
+                    file.getContentType(),
+                    file.getSize()
+            );
+
+        } catch (IOException e) {
+            throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String getExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            return "";
+        }
+
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
+
+    private String getFileUrl(String storedFileName) {
+        return "https://storage.googleapis.com/"
+                + bucketName
+                + "/"
+                + storedFileName;
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatFileServiceImpl.java
@@ -6,6 +6,7 @@ import com.capstone.pickIt.domain.chat.exception.ChatException;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatFileServiceImpl implements ChatFileService {
@@ -26,6 +28,7 @@ public class ChatFileServiceImpl implements ChatFileService {
 
     @Override
     public FileResponseDTO.UploadResponse uploadFiles(
+            Long currentUserId,
             List<MultipartFile> files
     ) {
         if (files == null || files.isEmpty()) {
@@ -36,16 +39,19 @@ public class ChatFileServiceImpl implements ChatFileService {
 
         try {
             List<FileResponseDTO.FileInfo> uploadedFiles = files.stream()
-                    .map(file -> uploadSingleFile(file, uploadedObjectNames))
+                    .map(file -> uploadSingleFile(currentUserId, file, uploadedObjectNames))
                     .toList();
 
             return new FileResponseDTO.UploadResponse(uploadedFiles);
 
         } catch (Exception e) {
+            log.error("GCS 파일 업로드 실패", e);
+
             uploadedObjectNames.forEach(objectName -> {
                 try {
                     storage.delete(bucketName, objectName);
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                }
             });
 
             throw new ChatException(ChatErrorCode.FILE_UPLOAD_FAILED);
@@ -53,6 +59,7 @@ public class ChatFileServiceImpl implements ChatFileService {
     }
 
     private FileResponseDTO.FileInfo uploadSingleFile(
+            Long currentUserId,
             MultipartFile file,
             List<String> uploadedObjectNames
     ) {
@@ -62,7 +69,7 @@ public class ChatFileServiceImpl implements ChatFileService {
 
         String originalFileName = file.getOriginalFilename();
         String extension = getExtension(originalFileName);
-        String storedFileName = "chat/" + UUID.randomUUID() + extension;
+        String storedFileName = "chat/" + currentUserId + "/" + UUID.randomUUID() + extension;
 
         try {
             BlobInfo blobInfo = BlobInfo.newBuilder(
@@ -83,8 +90,8 @@ public class ChatFileServiceImpl implements ChatFileService {
             return new FileResponseDTO.FileInfo(
                     originalFileName,
                     getFileUrl(storedFileName),
-                    file.getContentType(),
-                    file.getSize()
+                    file.getSize(),
+                    file.getContentType()
             );
 
         } catch (IOException e) {

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -10,6 +10,7 @@ import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
 import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
 import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
+import com.capstone.pickIt.domain.chat.repository.MessageFileRepository;
 import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
@@ -40,6 +41,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     private final UserCourseProfileRepository userCourseProfileRepository;
     private final TeamRequestRepository teamRequestRepository;
     private final MessageRepository messageRepository;
+    private final MessageFileRepository messageFileRepository;
 
     @Override
     public CommonCourseResponseDTO.CommonCourseList getCommonCourses(
@@ -256,13 +258,21 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                         ChatPartRepository.UnreadMemberCountProjection::getUnreadMemberCount
                 ));
 
+        Map<Long, List<MessageFile>> fileMap = messageFileRepository
+                .findByMessageIdIn(messageIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        messageFile -> messageFile.getMessage().getId()
+                ));
+
         List<ChatMessageResponseDTO.MessageSummary> messageSummaries =
                 messages.stream()
                         .map(message ->
                                 ChatMessageConverter.toMessageSummary(
                                         message,
                                         currentUserId,
-                                        unreadCountMap
+                                        unreadCountMap,
+                                        fileMap
                                 )
                         )
                         .toList();

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -368,11 +368,17 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     }
 
     private String getLastMessageContent(ChatRoom chatRoom) {
-        if (chatRoom.getLastMessage() == null) {
+        Message lastMessage = chatRoom.getLastMessage();
+
+        if (lastMessage == null) {
             return null;
         }
 
-        return chatRoom.getLastMessage().getContent();
+        if (lastMessage.getMessageType() == MessageType.FILE) {
+            return "파일을 보냈습니다.";
+        }
+
+        return lastMessage.getContent();
     }
 
     private ChatRoomResponseDTO.Opponent getOpponentOrNull(

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -79,6 +79,21 @@ public enum ChatErrorCode implements BaseCode {
             "CHAT400_14",
             "이미 나간 채팅방입니다."
     ),
+    FILE_COUNT_EXCEEDED(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_15",
+            "파일은 최대 5개까지 업로드할 수 있습니다."
+    ),
+    INVALID_FILE_TYPE(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_16",
+            "지원하지 않는 파일 형식입니다."
+    ),
+    FILE_SIZE_EXCEEDED(
+            HttpStatus.BAD_REQUEST,
+            "CHAT400_17",
+            "파일 크기는 20MB를 초과할 수 없습니다."
+    ),
     NOT_CHAT_ROOM_PARTICIPANT(
             HttpStatus.FORBIDDEN,
             "CHAT403_1",

--- a/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/exception/ChatErrorCode.java
@@ -153,6 +153,11 @@ public enum ChatErrorCode implements BaseCode {
             HttpStatus.CONFLICT,
             "CHAT409_5",
             "이미 해당 과목의 모집 중이거나 진행 중인 팀에 참여 중입니다."
+    ),
+    FILE_UPLOAD_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "CHAT500_1",
+            "파일 업로드에 실패했습니다."
     );
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageFileRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageFileRepository.java
@@ -3,5 +3,9 @@ package com.capstone.pickIt.domain.chat.repository;
 import com.capstone.pickIt.domain.chat.entity.MessageFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MessageFileRepository extends JpaRepository<MessageFile, Long> {
+
+    List<MessageFile> findByMessageIdIn(List<Long> messageIds);
 }

--- a/src/main/java/com/capstone/pickIt/global/config/storage/GcsConfig.java
+++ b/src/main/java/com/capstone/pickIt/global/config/storage/GcsConfig.java
@@ -1,0 +1,17 @@
+package com.capstone.pickIt.global.config.storage;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GcsConfig {
+
+    @Bean
+    public Storage storage() {
+        return StorageOptions
+                .getDefaultInstance()
+                .getService();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
             enable: true
             required: true
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 100MB
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,10 @@ jwt:
   access-token-expire-ms: 3600000
   refresh-token-expire-ms: 86400000
 
+gcp:
+  storage:
+    bucket: pickit-chat-files
+
 management:
   endpoints:
     web:
@@ -57,8 +61,8 @@ app:
       http://127.0.0.1:5500,
       http://localhost:5500,
       https://pick-it.site,
-      https://www.pick-it.site
-      http://localhost:5173
+      https://www.pick-it.site,
+      http://localhost:5173,
       http://localhost:3000
 
 logging:


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #119 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

파일 업로드 API 구현 (`POST /api/chats/files`)
- Google Cloud Storage(GCS) 기반 파일 업로드 기능 구현
- 다중 파일 업로드 지원
- 업로드 성공 시 파일 URL 및 메타데이터 반환
- 업로드 실패 시 이미 업로드된 파일 삭제 처리(보상 처리)
- 사용자별 저장 경로 분리 (`chat/{userId}/`)
- 파일 업로드 제한 정책 추가
  - 최대 업로드 파일 개수: 5개
  - 파일 1개당 최대 크기: 20MB
  - 요청 전체 최대 크기: 100MB
  - 지원 파일 형식 제한 (png, jpg/jpeg, webp, pdf, doc/docx, ppt/pptx, xls/xlsx, txt)

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- `gcloud auth application-default login`을 통해 로컬 GCP 인증 설정
- `gcloud auth application-default print-access-token`으로 인증 정상 적용 확인
- Swagger로 다중 파일 업로드 요청 테스트 완료
- 업로드된 파일이 GCS 버킷(`pickit-chat-files`)에 정상 저장되는 것 확인
- 업로드 응답으로 파일 URL 및 메타데이터 정상 반환 확인

<img width="1820" height="880" alt="다중 파일 업로드" src="https://github.com/user-attachments/assets/53cdf80f-a02d-4d1c-a466-bf7d10e71478" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅에서 파일 업로드 기능 추가 - 사용자는 이제 채팅방에서 여러 파일을 동시에 업로드할 수 있습니다.
  * 업로드된 파일이 메시지와 함께 표시되어 채팅 이력에서 첨부파일을 쉽게 확인할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->