### PR TITLE
[Feat] 팀 확정 및 나가기 관련 API 구현

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/project/controller/TeamMemberController.java
+++ b/src/main/java/com/capstone/pickIt/api/project/controller/TeamMemberController.java
@@ -1,0 +1,58 @@
+package com.capstone.pickIt.api.project.controller;
+
+import com.capstone.pickIt.api.project.dto.response.ConfirmResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.TeamLeaveRequestResponseDTO;
+import com.capstone.pickIt.api.project.service.TeamMemberService;
+import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
+import com.capstone.pickIt.global.apiPayload.response.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Team Member", description = "팀원 확정 및 나가기 API")
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamMemberController {
+
+    private final TeamMemberService teamMemberService;
+
+    @Operation(summary = "팀원 확정", description = "PENDING 상태에서 확정 버튼을 누릅니다. 전원 확정 시 팀이 IN_PROGRESS로 전환됩니다.")
+    @PatchMapping("/{projectTeamId}/confirm")
+    public ApiResponse<ConfirmResponseDTO> confirm(
+            @PathVariable Long projectTeamId) {
+        return ApiResponse.onSuccess(SuccessCode.OK, teamMemberService.confirm(projectTeamId));
+    }
+
+    @Operation(summary = "팀 나가기 (PENDING)", description = "확정 전(PENDING) 상태에서 팀을 나갑니다. 패널티 없음.")
+    @DeleteMapping("/{projectTeamId}/leave")
+    public ApiResponse<Void> leavePending(
+            @PathVariable Long projectTeamId) {
+        teamMemberService.leavePending(projectTeamId);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+
+    @Operation(summary = "나가기 요청 (CONFIRMED)", description = "확정 후 팀원 전원의 동의를 받아 나가기를 요청합니다.")
+    @PostMapping("/{projectTeamId}/leave/request")
+    public ApiResponse<TeamLeaveRequestResponseDTO> requestLeave(
+            @PathVariable Long projectTeamId) {
+        return ApiResponse.onSuccess(SuccessCode.CREATED, teamMemberService.requestLeave(projectTeamId));
+    }
+
+    @Operation(summary = "나가기 인정", description = "다른 팀원의 나가기 요청에 동의합니다. 전원 동의 시 해당 팀원이 팀을 나갑니다.")
+    @PostMapping("/{projectTeamId}/leave/approve")
+    public ApiResponse<Void> approveLeave(
+            @PathVariable Long projectTeamId) {
+        teamMemberService.approveLeave(projectTeamId);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+
+    @Operation(summary = "강제 나가기 (CONFIRMED)", description = "확정 후 동의 없이 팀을 나갑니다. 포인트 감점 패널티가 적용됩니다.")
+    @DeleteMapping("/{projectTeamId}/leave/force")
+    public ApiResponse<Void> leaveForce(
+            @PathVariable Long projectTeamId) {
+        teamMemberService.leaveForce(projectTeamId);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/project/dto/response/ConfirmResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/project/dto/response/ConfirmResponseDTO.java
@@ -1,0 +1,14 @@
+package com.capstone.pickIt.api.project.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConfirmResponseDTO {
+
+    private Long projectTeamId;
+    private String myRecruitmentConfirmStatus;  // CONFIRMED
+    private boolean allConfirmed;               // 전원 확정 여부
+    private String projectTeamStatus;           // RECRUITING or IN_PROGRESS
+}

--- a/src/main/java/com/capstone/pickIt/api/project/dto/response/TeamLeaveRequestResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/project/dto/response/TeamLeaveRequestResponseDTO.java
@@ -1,0 +1,14 @@
+package com.capstone.pickIt.api.project.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TeamLeaveRequestResponseDTO {
+
+    private Long teamLeaveRequestId;
+    private Long projectTeamId;
+    private Long requesterId;
+    private String status;  // PENDING
+}

--- a/src/main/java/com/capstone/pickIt/api/project/exception/ProjectExceptionHandler.java
+++ b/src/main/java/com/capstone/pickIt/api/project/exception/ProjectExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.capstone.pickIt.api.project.exception;
+
+import com.capstone.pickIt.domain.project.exception.ProjectException;
+import com.capstone.pickIt.global.apiPayload.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ProjectExceptionHandler {
+
+    @ExceptionHandler(ProjectException.class)
+    public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException e) {
+        log.error("ProjectException 발생: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.onFailure(e.getErrorCode(), null));
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/project/service/TeamMemberService.java
+++ b/src/main/java/com/capstone/pickIt/api/project/service/TeamMemberService.java
@@ -1,0 +1,22 @@
+package com.capstone.pickIt.api.project.service;
+
+import com.capstone.pickIt.api.project.dto.response.ConfirmResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.TeamLeaveRequestResponseDTO;
+
+public interface TeamMemberService {
+
+    // 팀원 확정 (PENDING → CONFIRMED, 전원 확정 시 팀 IN_PROGRESS)
+    ConfirmResponseDTO confirm(Long projectTeamId);
+
+    // 팀 나가기 - PENDING 상태 (패널티 없음, Case 1)
+    void leavePending(Long projectTeamId);
+
+    // 나가기 요청 생성 - CONFIRMED/IN_PROGRESS (Case 3-1)
+    TeamLeaveRequestResponseDTO requestLeave(Long projectTeamId);
+
+    // 나가기 인정 - 다른 팀원이 나가기 요청에 동의 (Case 3-1)
+    void approveLeave(Long projectTeamId);
+
+    /** 강제 나가기 - CONFIRMED/IN_PROGRESS (포인트 감점, Case 3-2) */
+    void leaveForce(Long projectTeamId);
+}

--- a/src/main/java/com/capstone/pickIt/api/project/service/TeamMemberServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/project/service/TeamMemberServiceImpl.java
@@ -1,0 +1,274 @@
+package com.capstone.pickIt.api.project.service;
+
+import com.capstone.pickIt.api.project.dto.response.ConfirmResponseDTO;
+import com.capstone.pickIt.api.project.dto.response.TeamLeaveRequestResponseDTO;
+import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
+import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
+import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
+import com.capstone.pickIt.domain.project.entity.*;
+import com.capstone.pickIt.domain.project.exception.ProjectErrorCode;
+import com.capstone.pickIt.domain.project.exception.ProjectException;
+import com.capstone.pickIt.domain.project.repository.*;
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.domain.user.exception.UserErrorCode;
+import com.capstone.pickIt.domain.user.exception.UserException;
+import com.capstone.pickIt.domain.user.repository.UserRepository;
+import com.capstone.pickIt.global.config.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamMemberServiceImpl implements TeamMemberService {
+
+    private final ProjectTeamRepository projectTeamRepository;
+    private final ProjectTeamMemberRepository projectTeamMemberRepository;
+    private final TeamLeaveRequestRepository teamLeaveRequestRepository;
+    private final TeamLeaveApprovalRepository teamLeaveApprovalRepository;
+    private final UserCourseProfileRepository userCourseProfileRepository;
+    private final UserRepository userRepository;
+
+
+     // 팀원 확정
+     // PENDING -> CONFIRMED
+     // first_confirmed_at 기록 (최초 1회)
+     // 48시간 초과 시 예외
+     // 전원 확정 시 -> ProjectTeam IN_PROGRESS, 모든 카드 RECRUITMENT_COMPLETED
+    @Override
+    @Transactional
+    public ConfirmResponseDTO confirm(Long projectTeamId) {
+        Long userId = SecurityUtil.requireUserId();
+
+        ProjectTeam team = findTeam(projectTeamId);
+
+        // 48시간 초과 체크
+        if (team.isConfirmWindowExpired()) {
+            throw new ProjectException(ProjectErrorCode.CONFIRM_WINDOW_EXPIRED);
+        }
+
+        ProjectTeamMember member = findActiveMember(projectTeamId, userId);
+
+        // 이미 확정한 경우
+        if (member.getRecruitmentConfirmStatus() == RecruitmentConfirmStatus.CONFIRMED) {
+            throw new ProjectException(ProjectErrorCode.ALREADY_CONFIRMED);
+        }
+
+        // PENDING 상태 확인
+        if (member.getRecruitmentConfirmStatus() != RecruitmentConfirmStatus.PENDING) {
+            throw new ProjectException(ProjectErrorCode.NOT_PENDING_MEMBER);
+        }
+
+        // 확정 처리
+        member.confirm();
+        team.recordFirstConfirmedAt();
+
+        // 전원 확정 여부 확인
+        List<ProjectTeamMember> activeMembers = projectTeamMemberRepository
+                .findAllByProjectTeamIdAndLeftAtIsNull(projectTeamId);
+        boolean allConfirmed = activeMembers.stream()
+                .allMatch(m -> m.getRecruitmentConfirmStatus() == RecruitmentConfirmStatus.CONFIRMED);
+
+        if (allConfirmed) {
+            // 팀 IN_PROGRESS 전환
+            team.start();
+
+            // 모든 팀원 카드 RECRUITMENT_COMPLETED 처리
+            Long courseId = team.getCourse().getId();
+            for (ProjectTeamMember m : activeMembers) {
+                userCourseProfileRepository
+                        .findByUserIdAndCourseIdAndDeletedAtIsNull(m.getUser().getId(), courseId)
+                        .ifPresent(profile -> profile.changeRecruitmentStatus(RecruitmentStatus.RECRUITMENT_COMPLETED));
+            }
+        }
+
+        return ConfirmResponseDTO.builder()
+                .projectTeamId(projectTeamId)
+                .myRecruitmentConfirmStatus(RecruitmentConfirmStatus.CONFIRMED.name())
+                .allConfirmed(allConfirmed)
+                .projectTeamStatus(team.getStatus().name())
+                .build();
+    }
+
+     // 팀 나가기 - PENDING 상태 (패널티 없음)
+     // leftAt 설정
+     // 본인 카드 + 나머지 팀원 카드 -> RECRUITING 복구
+     // ProjectTeam 유지 (재모집 가능)
+    @Override
+    @Transactional
+    public void leavePending(Long projectTeamId) {
+        Long userId = SecurityUtil.requireUserId();
+
+        ProjectTeam team = findTeam(projectTeamId);
+        ProjectTeamMember member = findActiveMember(projectTeamId, userId);
+
+        // PENDING 상태 확인
+        if (member.getRecruitmentConfirmStatus() != RecruitmentConfirmStatus.PENDING) {
+            throw new ProjectException(ProjectErrorCode.NOT_PENDING_MEMBER);
+        }
+
+        // 나가기 처리
+        member.leave();
+
+        // 모든 팀원(본인 포함) 카드 -> RECRUITING 복구
+        Long courseId = team.getCourse().getId();
+        List<ProjectTeamMember> activeMembers = projectTeamMemberRepository
+                .findAllByProjectTeamIdAndLeftAtIsNull(projectTeamId);
+
+        // 나가는 본인 카드도 복구
+        restoreProfileToRecruiting(userId, courseId);
+
+        // 남은 팀원 카드 복구
+        for (ProjectTeamMember m : activeMembers) {
+            restoreProfileToRecruiting(m.getUser().getId(), courseId);
+        }
+    }
+
+     // 나가기 요청 생성
+     // CONFIRMED 상태 멤버만 가능
+     // 팀에 이미 PENDING 요청이 있으면 예외
+    @Override
+    @Transactional
+    public TeamLeaveRequestResponseDTO requestLeave(Long projectTeamId) {
+        Long userId = SecurityUtil.requireUserId();
+
+        ProjectTeam team = findTeam(projectTeamId);
+        ProjectTeamMember member = findActiveMember(projectTeamId, userId);
+
+        // CONFIRMED 상태 확인
+        if (member.getRecruitmentConfirmStatus() != RecruitmentConfirmStatus.CONFIRMED) {
+            throw new ProjectException(ProjectErrorCode.NOT_CONFIRMED_MEMBER);
+        }
+
+        // 이미 PENDING 나가기 요청이 있는지 확인
+        if (teamLeaveRequestRepository.existsByProjectTeamIdAndStatus(
+                projectTeamId, TeamLeaveRequestStatus.PENDING)) {
+            throw new ProjectException(ProjectErrorCode.LEAVE_REQUEST_ALREADY_EXISTS);
+        }
+
+        User user = findUser(userId);
+        TeamLeaveRequest leaveRequest = TeamLeaveRequest.create(team, user);
+        teamLeaveRequestRepository.save(leaveRequest);
+
+        // 팀원들한테 나가기 요청 알림 해야함.
+
+        return TeamLeaveRequestResponseDTO.builder()
+                .teamLeaveRequestId(leaveRequest.getId())
+                .projectTeamId(projectTeamId)
+                .requesterId(userId)
+                .status(leaveRequest.getStatus().name())
+                .build();
+    }
+
+     // 나가기 인정
+     // 현재 유저가 팀의 PENDING 나가기 요청에 동의
+     // 본인 요청은 인정 불가
+     // 전원 인정 시 -> 요청자 나가기 처리, 요청자 카드 RECRUITING 복구
+    @Override
+    @Transactional
+    public void approveLeave(Long projectTeamId) {
+        Long userId = SecurityUtil.requireUserId();
+
+        // 팀 멤버인지 확인 (CONFIRMED)
+        findActiveMember(projectTeamId, userId);
+
+        // PENDING 나가기 요청 조회
+        TeamLeaveRequest leaveRequest = teamLeaveRequestRepository
+                .findByProjectTeamIdAndStatus(projectTeamId, TeamLeaveRequestStatus.PENDING)
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.LEAVE_REQUEST_NOT_FOUND));
+
+        // 본인 요청은 인정 불가
+        if (leaveRequest.getRequester().getId().equals(userId)) {
+            throw new ProjectException(ProjectErrorCode.CANNOT_APPROVE_OWN_LEAVE_REQUEST);
+        }
+
+        // 이미 인정했는지 확인
+        if (teamLeaveApprovalRepository.existsByTeamLeaveRequestIdAndApproverId(
+                leaveRequest.getId(), userId)) {
+            throw new ProjectException(ProjectErrorCode.ALREADY_APPROVED_LEAVE);
+        }
+
+        // 인정 기록 저장
+        User approver = findUser(userId);
+        teamLeaveApprovalRepository.save(TeamLeaveApproval.create(leaveRequest, approver));
+
+        // 전원 인정 여부 확인 (요청자를 제외한 나머지 CONFIRMED 멤버 수 vs 인정 수)
+        List<ProjectTeamMember> activeMembers = projectTeamMemberRepository
+                .findAllByProjectTeamIdAndLeftAtIsNull(projectTeamId);
+
+        long requiredApprovals = activeMembers.stream()
+                .filter(m -> m.getRecruitmentConfirmStatus() == RecruitmentConfirmStatus.CONFIRMED)
+                .filter(m -> !m.getUser().getId().equals(leaveRequest.getRequester().getId()))
+                .count();
+
+        long currentApprovals = teamLeaveApprovalRepository.countByTeamLeaveRequestId(leaveRequest.getId());
+
+        if (currentApprovals >= requiredApprovals) {
+            // 전원 인정 → 나가기 처리
+            leaveRequest.approve();
+
+            ProjectTeamMember requesterMember = findActiveMember(
+                    projectTeamId, leaveRequest.getRequester().getId());
+            requesterMember.leave();
+
+            // 요청자 카드 RECRUITING 복구
+            Long courseId = leaveRequest.getProjectTeam().getCourse().getId();
+            restoreProfileToRecruiting(leaveRequest.getRequester().getId(), courseId);
+        }
+    }
+
+     // 강제 나가기 (포인트 감점)
+     // CONFIRMED 상태 멤버만 가능
+     // leftAt 설정
+     // 본인 카드 RECRUITING 복구
+     // 포인트 감점
+    @Override
+    @Transactional
+    public void leaveForce(Long projectTeamId) {
+        Long userId = SecurityUtil.requireUserId();
+
+        ProjectTeam team = findTeam(projectTeamId);
+        ProjectTeamMember member = findActiveMember(projectTeamId, userId);
+
+        // CONFIRMED 상태 확인
+        if (member.getRecruitmentConfirmStatus() != RecruitmentConfirmStatus.CONFIRMED) {
+            throw new ProjectException(ProjectErrorCode.NOT_CONFIRMED_MEMBER);
+        }
+
+        // 나가기 처리
+        member.leave();
+
+        // 본인 카드 RECRUITING 복구
+        Long courseId = team.getCourse().getId();
+        restoreProfileToRecruiting(userId, courseId);
+
+        // 포인트 감점 처리 해야함!!!!!!!!!!!!
+    }
+
+    // 기타 필요 메서드
+
+    private ProjectTeam findTeam(Long projectTeamId) {
+        return projectTeamRepository.findById(projectTeamId)
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.PROJECT_TEAM_NOT_FOUND));
+    }
+
+    private ProjectTeamMember findActiveMember(Long projectTeamId, Long userId) {
+        return projectTeamMemberRepository
+                .findByProjectTeamIdAndUserIdAndLeftAtIsNull(projectTeamId, userId)
+                .orElseThrow(() -> new ProjectException(ProjectErrorCode.TEAM_MEMBER_NOT_FOUND));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private void restoreProfileToRecruiting(Long userId, Long courseId) {
+        userCourseProfileRepository
+                .findByUserIdAndCourseIdAndDeletedAtIsNull(userId, courseId)
+                .ifPresent(profile -> profile.changeRecruitmentStatus(RecruitmentStatus.RECRUITING));
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/ProjectTeam.java
@@ -49,6 +49,9 @@ public class ProjectTeam extends BaseEntity {
     @Column(name = "ended_at")
     private LocalDateTime endedAt;
 
+    @Column(name = "first_confirmed_at")
+    private LocalDateTime firstConfirmedAt;
+
     public void start() {
         if (this.status != ProjectTeamStatus.RECRUITING) {
             throw new IllegalStateException("Project team은 RECRUITING 상태에서만 시작 가능합니다.");
@@ -73,6 +76,19 @@ public class ProjectTeam extends BaseEntity {
         if (this.status == null) {
             this.status = ProjectTeamStatus.RECRUITING;
         }
+    }
+
+    /** 최초 확정 시각 기록 (한 번만 세팅) */
+    public void recordFirstConfirmedAt() {
+        if (this.firstConfirmedAt == null) {
+            this.firstConfirmedAt = LocalDateTime.now();
+        }
+    }
+
+    /** 최초 확정 후 48시간 초과 여부 */
+    public boolean isConfirmWindowExpired() {
+        if (this.firstConfirmedAt == null) return false;
+        return LocalDateTime.now().isAfter(this.firstConfirmedAt.plusHours(48));
     }
 
     public static ProjectTeam createRecruitingTeam(Course course) {

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveApproval.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveApproval.java
@@ -1,0 +1,43 @@
+package com.capstone.pickIt.domain.project.entity;
+
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "team_leave_approval",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_team_leave_approval_request_approver",
+                        columnNames = {"team_leave_request_id", "approver_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TeamLeaveApproval extends CreatedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_leave_approval_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_leave_request_id", nullable = false)
+    private TeamLeaveRequest teamLeaveRequest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approver_id", nullable = false)
+    private User approver;
+
+    public static TeamLeaveApproval create(TeamLeaveRequest teamLeaveRequest, User approver) {
+        return TeamLeaveApproval.builder()
+                .teamLeaveRequest(teamLeaveRequest)
+                .approver(approver)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveRequest.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveRequest.java
@@ -1,0 +1,44 @@
+package com.capstone.pickIt.domain.project.entity;
+
+import com.capstone.pickIt.domain.user.entity.User;
+import com.capstone.pickIt.global.entity.CreatedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "team_leave_request")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TeamLeaveRequest extends CreatedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_leave_request_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_team_id", nullable = false)
+    private ProjectTeam projectTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private User requester;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private TeamLeaveRequestStatus status;
+
+    public void approve() {
+        this.status = TeamLeaveRequestStatus.APPROVED;
+    }
+
+    public static TeamLeaveRequest create(ProjectTeam projectTeam, User requester) {
+        return TeamLeaveRequest.builder()
+                .projectTeam(projectTeam)
+                .requester(requester)
+                .status(TeamLeaveRequestStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveRequestStatus.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/entity/TeamLeaveRequestStatus.java
@@ -1,0 +1,7 @@
+package com.capstone.pickIt.domain.project.entity;
+
+public enum TeamLeaveRequestStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/exception/ProjectErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/exception/ProjectErrorCode.java
@@ -12,6 +12,16 @@ public enum ProjectErrorCode implements BaseCode {
     NOT_PROJECT_MEMBER(HttpStatus.FORBIDDEN, "PROJECT403_1", "해당 프로젝트 팀의 멤버만 접근할 수 있습니다."),
 
     PROJECT_TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_1", "프로젝트 팀을 찾을 수 없습니다."),
+    TEAM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_2", "팀 멤버를 찾을 수 없습니다."),
+    LEAVE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404_3", "나가기 요청을 찾을 수 없습니다."),
+
+    NOT_PENDING_MEMBER(HttpStatus.BAD_REQUEST, "PROJECT400_1", "PENDING 상태의 멤버만 나가기 가능합니다."),
+    NOT_CONFIRMED_MEMBER(HttpStatus.BAD_REQUEST, "PROJECT400_2", "CONFIRMED 상태의 멤버만 이 작업을 수행할 수 있습니다."),
+    ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "PROJECT400_3", "이미 확정한 멤버입니다."),
+    CONFIRM_WINDOW_EXPIRED(HttpStatus.BAD_REQUEST, "PROJECT400_4", "확정 가능 기간(48시간)이 초과되었습니다."),
+    LEAVE_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT409_1", "이미 진행 중인 나가기 요청이 있습니다."),
+    ALREADY_APPROVED_LEAVE(HttpStatus.CONFLICT, "PROJECT409_2", "이미 인정한 나가기 요청입니다."),
+    CANNOT_APPROVE_OWN_LEAVE_REQUEST(HttpStatus.FORBIDDEN, "PROJECT403_2", "본인의 나가기 요청은 인정할 수 없습니다."),
 
     ;
 

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -8,10 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMember, Long> {
 
     List<ProjectTeamMember> findByProjectTeam_Id(Long projectTeamId);
+
+    Optional<ProjectTeamMember> findByProjectTeamIdAndUserIdAndLeftAtIsNull(Long projectTeamId, Long userId);
+
+    List<ProjectTeamMember> findAllByProjectTeamIdAndLeftAtIsNull(Long projectTeamId);
 
     boolean existsByProjectTeamIdAndUserId(Long projectTeamId, Long userId);
 

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamLeaveApprovalRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamLeaveApprovalRepository.java
@@ -1,0 +1,15 @@
+package com.capstone.pickIt.domain.project.repository;
+
+import com.capstone.pickIt.domain.project.entity.TeamLeaveApproval;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TeamLeaveApprovalRepository extends JpaRepository<TeamLeaveApproval, Long> {
+
+    List<TeamLeaveApproval> findByTeamLeaveRequestId(Long teamLeaveRequestId);
+
+    boolean existsByTeamLeaveRequestIdAndApproverId(Long teamLeaveRequestId, Long approverId);
+
+    long countByTeamLeaveRequestId(Long teamLeaveRequestId);
+}

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamLeaveRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamLeaveRequestRepository.java
@@ -1,0 +1,14 @@
+package com.capstone.pickIt.domain.project.repository;
+
+import com.capstone.pickIt.domain.project.entity.TeamLeaveRequest;
+import com.capstone.pickIt.domain.project.entity.TeamLeaveRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamLeaveRequestRepository extends JpaRepository<TeamLeaveRequest, Long> {
+
+    Optional<TeamLeaveRequest> findByProjectTeamIdAndStatus(Long projectTeamId, TeamLeaveRequestStatus status);
+
+    boolean existsByProjectTeamIdAndStatus(Long projectTeamId, TeamLeaveRequestStatus status);
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
#52
closes #52

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 팀원 확정 버튼
- 팀 확정 전 팀 나가기
- 팀 나가기 요청
- 나가기 인정 버튼
- 그냥 나가기(포인트 감점)

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 팀원들에게 나가기 요청 알림 API 추가해서 다시 테스트할 예정