### PR TITLE
[Refactor] 팀 프로젝트 형성 시 강의 삭제 불가

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
@@ -19,6 +19,8 @@ import com.capstone.pickIt.domain.trait.entity.TraitItem;
 import com.capstone.pickIt.domain.trait.exception.TraitErrorCode;
 import com.capstone.pickIt.domain.trait.exception.TraitException;
 import com.capstone.pickIt.domain.trait.repository.TraitItemRepository;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
+import com.capstone.pickIt.domain.project.repository.ProjectTeamMemberRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
 import com.capstone.pickIt.global.apiPayload.response.ErrorCode;
@@ -39,6 +41,7 @@ public class MypageCourseService {
     private final CourseRepository courseRepository;
     private final TraitItemRepository traitItemRepository;
     private final UserRepository userRepository;
+    private final ProjectTeamMemberRepository projectTeamMemberRepository;
 
     @Transactional(readOnly = true)
     public List<CourseListResponseDTO> getCourseList(Long userId) {
@@ -91,6 +94,14 @@ public class MypageCourseService {
         UserCourseProfile profile = userCourseProfileRepository
                 .findByUserIdAndCourseIdAndDeletedAtIsNull(userId, courseId)
                 .orElseThrow(() -> new ProfileException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        boolean hasActiveTeam = projectTeamMemberRepository.existsActiveTeamByCourseAndUser(
+                courseId, userId,
+                List.of(ProjectTeamStatus.RECRUITING, ProjectTeamStatus.IN_PROGRESS)
+        );
+        if (hasActiveTeam) {
+            throw new ProfileException(ProfileErrorCode.COURSE_HAS_ACTIVE_TEAM);
+        }
 
         userCourseTraitRepository.deleteByUserCourseProfileId(profile.getId());
         userCourseRepository.deleteByUserIdAndCourseId(userId, courseId);

--- a/src/main/java/com/capstone/pickIt/domain/course/exception/ProfileErrorCode.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/exception/ProfileErrorCode.java
@@ -12,7 +12,8 @@ public enum ProfileErrorCode implements BaseCode {
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE404", "존재하지 않는 프로필입니다."),
     PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROFILE409", "해당 강의에 이미 프로필이 존재합니다."),
     PROFILE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PROFILE403", "해당 프로필에 접근 권한이 없습니다."),
-    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE404_1", "존재하지 않는 강의입니다.");
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE404_1", "존재하지 않는 강의입니다."),
+    COURSE_HAS_ACTIVE_TEAM(HttpStatus.CONFLICT, "PROFILE409_1", "팀이 구성된 강의는 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -22,6 +22,7 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
         WHERE pt.course.id = :courseId
         AND ptm.user.id = :userId
         AND ptm.leftAt IS NULL
+        AND ptm.recruitmentConfirmStatus = com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus.CONFIRMED
         AND pt.status IN :statuses
     """)
     boolean existsActiveTeamByCourseAndUser(


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #100 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  마이페이지에서 강의 삭제 시, 해당 강의에서 팀이 구성된 경우(RECRUITING / IN_PROGRESS) 삭제를 막는 검증 로직 추가
                                                                                                                                                                                                         
  - `ProfileErrorCode`에 `COURSE_HAS_ACTIVE_TEAM` 에러 코드 추가 (409 Conflict)
  - `MypageCourseService.deleteCourse()`에서 삭제 전 `ProjectTeamMemberRepository.existsActiveTeamByCourseAndUser()`로 팀 참여 여부 확인
  - RECRUITING 또는 IN_PROGRESS 상태의 팀에 속해 있으면 예외 발생, DONE 상태는 허용



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 활성 팀이 구성된 과목의 삭제를 방지하도록 개선했습니다.
  * 과목 관련 오류에 대한 명확한 오류 메시지를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->