### PR TITLE
[Refactor] 마이페이지 강의에 projectStatus 추가

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/CourseCardResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/CourseCardResponseDTO.java
@@ -2,6 +2,7 @@ package com.capstone.pickIt.api.user.dto.response;
 
 import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
 import com.capstone.pickIt.domain.course.entity.UserCourseTrait;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.trait.entity.TraitSide;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ public class CourseCardResponseDTO {
     private String courseName;
     private String semester;
     private String importance;
+    private ProjectTeamStatus projectStatus;
     private List<TraitInfo> traits;
 
     @Getter
@@ -38,12 +40,13 @@ public class CourseCardResponseDTO {
         }
     }
 
-    public static CourseCardResponseDTO from(UserCourseProfile profile, List<UserCourseTrait> traits) {
+    public static CourseCardResponseDTO from(UserCourseProfile profile, List<UserCourseTrait> traits, ProjectTeamStatus projectStatus) {
         return CourseCardResponseDTO.builder()
                 .courseId(profile.getCourse().getId())
                 .courseName(profile.getCourse().getCourseName())
                 .semester(profile.getCourse().getSemester())
                 .importance(profile.getImportanceLevel() != null ? profile.getImportanceLevel().name() : null)
+                .projectStatus(projectStatus)
                 .traits(traits.stream().map(TraitInfo::from).toList())
                 .build();
     }

--- a/src/main/java/com/capstone/pickIt/api/user/dto/response/CourseListResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/user/dto/response/CourseListResponseDTO.java
@@ -1,6 +1,7 @@
 package com.capstone.pickIt.api.user.dto.response;
 
 import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +11,13 @@ public class CourseListResponseDTO {
 
     private Long courseId;
     private String courseName;
+    private ProjectTeamStatus projectStatus;
 
-    public static CourseListResponseDTO from(UserCourseProfile profile) {
+    public static CourseListResponseDTO from(UserCourseProfile profile, ProjectTeamStatus projectStatus) {
         return CourseListResponseDTO.builder()
                 .courseId(profile.getCourse().getId())
                 .courseName(profile.getCourse().getCourseName())
+                .projectStatus(projectStatus)
                 .build();
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
@@ -30,6 +30,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -45,24 +47,42 @@ public class MypageCourseService {
 
     @Transactional(readOnly = true)
     public List<CourseListResponseDTO> getCourseList(Long userId) {
+        Map<Long, ProjectTeamStatus> courseStatusMap = buildCourseStatusMap(userId);
+
         return userCourseProfileRepository
                 .findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId)
                 .stream()
-                .map(CourseListResponseDTO::from)
+                .map(profile -> CourseListResponseDTO.from(
+                        profile,
+                        courseStatusMap.getOrDefault(profile.getCourse().getId(), ProjectTeamStatus.RECRUITING)
+                ))
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public List<CourseCardResponseDTO> getCourseCards(Long userId) {
+        Map<Long, ProjectTeamStatus> courseStatusMap = buildCourseStatusMap(userId);
+
         List<UserCourseProfile> profiles = userCourseProfileRepository
                 .findAllByUserIdAndDeletedAtIsNull(userId);
 
         return profiles.stream()
                 .map(profile -> CourseCardResponseDTO.from(
                         profile,
-                        userCourseTraitRepository.findByUserCourseProfileId(profile.getId())
+                        userCourseTraitRepository.findByUserCourseProfileId(profile.getId()),
+                        courseStatusMap.getOrDefault(profile.getCourse().getId(), ProjectTeamStatus.RECRUITING)
                 ))
                 .toList();
+    }
+
+    private Map<Long, ProjectTeamStatus> buildCourseStatusMap(Long userId) {
+        return projectTeamMemberRepository
+                .findActiveConfirmedMembershipsWithTeamAndCourse(userId, null)
+                .stream()
+                .collect(Collectors.toMap(
+                        m -> m.getProjectTeam().getCourse().getId(),
+                        m -> m.getProjectTeam().getStatus()
+                ));
     }
 
     @Transactional

--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageCourseService.java
@@ -81,7 +81,8 @@ public class MypageCourseService {
                 .stream()
                 .collect(Collectors.toMap(
                         m -> m.getProjectTeam().getCourse().getId(),
-                        m -> m.getProjectTeam().getStatus()
+                        m -> m.getProjectTeam().getStatus(),
+                        (existing, replacement) -> existing
                 ));
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #139

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  마이페이지 강의 응답에 projectStatus 필드 추가

  - GET /api/users/me/courses, GET /api/users/me/courses/card 응답에 projectStatus 추가
  - projectStatus는 해당 강의의 프로젝트 팀 상태(ProjectTeamStatus)를 반영
    - 확정된 팀(CONFIRMED 멤버십)이 있는 경우 → 해당 팀의 상태(RECRUITING / IN_PROGRESS / DONE)
    - 팀이 없는 경우 → RECRUITING (기본값)


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="887" height="278" alt="image" src="https://github.com/user-attachments/assets/763909e6-c13f-488d-b5c1-08abc7495d17" />
<img width="815" height="453" alt="image" src="https://github.com/user-attachments/assets/557d2e34-d263-4314-b00a-83a69c3a5f28" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 마이페이지의 과목 목록 조회에서 각 과목의 프로젝트 팀 상태(모집 중/확정 등) 정보 표시
* 과목 카드 조회 화면에서도 팀 상태 정보 포함으로 사용자가 팀 현황을 한눈에 파악 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->