### PR TITLE
[Refactor] 공통 과목 목록 조회 조건 보완

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
 import com.capstone.pickIt.domain.chat.repository.MessageFileRepository;
 import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
+import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
 import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
@@ -72,20 +73,29 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
         Long opponentUserId = opponentChatPart.getUser().getId();
 
-        boolean existsPendingForReceiver =
-                teamRequestRepository.existsBySenderIdAndReceiverIdAndTeamRequestStatus(
+        // 현재 두 사용자 사이에 PENDING 팀원 요청이 존재하면
+        // 추가 요청을 보내지 못하도록 공통 과목 목록 전체를 빈 배열로 반환
+        boolean existsPendingBetweenUsers =
+                teamRequestRepository.existsPendingBetweenUsers(
                         currentUserId,
                         opponentUserId,
                         TeamRequestStatus.PENDING
                 );
 
-        if (existsPendingForReceiver) {
+        if (existsPendingBetweenUsers) {
             return new CommonCourseResponseDTO.CommonCourseList(List.of());
         }
 
+        // 요청 가능한 공통 과목 조회
+        // - 현재 사용자가 다른 사용자에게 이미 PENDING 요청을 보낸 과목은 제외
+        // - 현재 상대방과 이미 ACCEPTED 된 과목은 양쪽 모두에게 제외
+        // - 두 사용자 모두 RECRUITING 상태인 공통 과목만 조회
         List<Course> commonCourses = userCourseProfileRepository.findRequestableCommonCourses(
                 currentUserId,
-                opponentChatPart.getUser().getId()
+                opponentUserId,
+                RecruitmentStatus.RECRUITING,
+                TeamRequestStatus.PENDING,
+                TeamRequestStatus.ACCEPTED
         );
 
         return CommonCourseConverter.toCommonCourseList(commonCourses);

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
@@ -3,6 +3,7 @@ package com.capstone.pickIt.domain.course.repository;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
 import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
+import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,20 +30,34 @@ public interface UserCourseProfileRepository extends JpaRepository<UserCoursePro
           AND ucp2.user.id = :opponentUserId
           AND ucp1.deletedAt IS NULL
           AND ucp2.deletedAt IS NULL
-          AND ucp1.recruitmentStatus = 'RECRUITING'
-          AND ucp2.recruitmentStatus = 'RECRUITING'
+          AND ucp1.recruitmentStatus = :recruitingStatus
+          AND ucp2.recruitmentStatus = :recruitingStatus
           AND NOT EXISTS (
               SELECT 1
               FROM TeamRequest tr
               WHERE tr.sender.id = :currentUserId
                 AND tr.course.id = ucp1.course.id
-                AND tr.teamRequestStatus = 'PENDING'
+                AND tr.teamRequestStatus = :pendingStatus
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM TeamRequest tr
+              WHERE tr.course.id = ucp1.course.id
+                AND tr.teamRequestStatus = :acceptedStatus
+                AND (
+                  (tr.sender.id = :currentUserId AND tr.receiver.id = :opponentUserId)
+                  OR
+                  (tr.sender.id = :opponentUserId AND tr.receiver.id = :currentUserId)
+                )
           )
         ORDER BY ucp1.course.courseName ASC
         """)
     List<Course> findRequestableCommonCourses(
-            Long currentUserId,
-            Long opponentUserId
+            @Param("currentUserId") Long currentUserId,
+            @Param("opponentUserId") Long opponentUserId,
+            @Param("recruitingStatus") RecruitmentStatus recruitingStatus,
+            @Param("pendingStatus") TeamRequestStatus pendingStatus,
+            @Param("acceptedStatus") TeamRequestStatus acceptedStatus
     );
 
     Optional<UserCourseProfile> findByUserIdAndCourseIdAndDeletedAtIsNull(

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -22,16 +22,26 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             TeamRequestStatus teamRequestStatus
     );
 
-    boolean existsBySenderIdAndReceiverIdAndTeamRequestStatus(
-            Long senderId,
-            Long receiverId,
-            TeamRequestStatus teamRequestStatus
-    );
-
     Page<TeamRequest> findByTeamRequestStatusAndCreatedAtLessThanEqual(
             TeamRequestStatus teamRequestStatus,
             LocalDateTime createdAt,
             Pageable pageable
+    );
+
+    @Query("""
+        SELECT COUNT(tr) > 0
+        FROM TeamRequest tr
+        WHERE tr.teamRequestStatus = :status
+        AND (
+            (tr.sender.id = :userId AND tr.receiver.id = :opponentUserId)
+            OR
+            (tr.sender.id = :opponentUserId AND tr.receiver.id = :userId)
+        )
+    """)
+    boolean existsPendingBetweenUsers(
+            @Param("userId") Long userId,
+            @Param("opponentUserId") Long opponentUserId,
+            @Param("status") TeamRequestStatus status
     );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -22,6 +22,12 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             TeamRequestStatus teamRequestStatus
     );
 
+    boolean existsBySenderIdAndReceiverIdAndTeamRequestStatus(
+            Long senderId,
+            Long receiverId,
+            TeamRequestStatus teamRequestStatus
+    );
+
     Page<TeamRequest> findByTeamRequestStatusAndCreatedAtLessThanEqual(
             TeamRequestStatus teamRequestStatus,
             LocalDateTime createdAt,


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #150 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### 공통 과목 목록 조회 조건 보완
- 두 사용자 사이에 `PENDING` 팀원 요청이 존재하는 경우, 양쪽 모두 공통 과목 목록을 빈 배열로 반환하도록 수정
  - 기존: 요청 송신자만 빈 배열 반환
  - 변경: 송신자/수신자 양방향 모두 빈 배열 반환
- 두 사용자 사이에서 이미 `ACCEPTED` 된 과목은 양쪽 모두 공통 과목 목록에서 제외되도록 수정
- 공통 과목 조회 JPQL enum 비교 방식 변경
  - 기존: 문자열 하드코딩
  - 변경: enum 파라미터 바인딩 방식


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 팀 요청이 대기 중인 경우 공통 과목 조회 처리 개선
  * 과목 모집 상태 및 팀 요청 상태 확인 로직 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->