### PR TITLE
[Feat] WebSocket 기반 채팅 목록 갱신 알림 추가

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatNotificationResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatNotificationResponseDTO.java
@@ -1,0 +1,23 @@
+package com.capstone.pickIt.api.chat.dto.response;
+
+import com.capstone.pickIt.domain.chat.entity.ChatType;
+import com.capstone.pickIt.domain.chat.entity.MessageType;
+
+import java.time.LocalDateTime;
+
+public class ChatNotificationResponseDTO {
+
+    public record ChatRoomNotification(
+            String eventType,
+            Long chatRoomId,
+            ChatType chatType,
+            Long messageId,
+            MessageType messageType,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            Long senderId,
+            String senderNickname,
+            Long unreadCount
+    ) {
+    }
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/event/ChatRoomBroadcastEventListener.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/event/ChatRoomBroadcastEventListener.java
@@ -23,6 +23,7 @@ public class ChatRoomBroadcastEventListener {
                 event.chatRoomId()
         );
 
+        // 채팅방 구독자에게 메시지 브로드캐스트
         messagingTemplate.convertAndSend(
                 "/topic/chatrooms/" + event.chatRoomId(),
                 event.payload()

--- a/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEvent.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEvent.java
@@ -1,0 +1,9 @@
+package com.capstone.pickIt.api.chat.event;
+
+import com.capstone.pickIt.api.chat.dto.response.ChatNotificationResponseDTO;
+
+public record ChatUserNotificationEvent(
+        Long receiverId,
+        ChatNotificationResponseDTO.ChatRoomNotification payload
+) {
+}

--- a/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
@@ -7,24 +7,25 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@Slf4j
-public class ChatRoomBroadcastEventListener {
+public class ChatUserNotificationEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(ChatRoomBroadcastEvent event) {
+    public void handle(ChatUserNotificationEvent event) {
+        String destination = "/queue/notifications/" + event.receiverId();
 
         log.info(
-                "Broadcasting chat room event: chatRoomId={}, destination=/topic/chatrooms/{}",
-                event.chatRoomId(),
-                event.chatRoomId()
+                "Sending chat notification: receiverId={}, destination={}",
+                event.receiverId(),
+                destination
         );
 
         messagingTemplate.convertAndSend(
-                "/topic/chatrooms/" + event.chatRoomId(),
+                destination,
                 event.payload()
         );
     }

--- a/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
@@ -24,6 +24,8 @@ public class ChatUserNotificationEventListener {
                 destination
         );
 
+        // TODO: UserDestination 설정이 안정화되면
+        // /user/queue/notifications 방식으로 전환
         messagingTemplate.convertAndSend(
                 destination,
                 event.payload()

--- a/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/event/ChatUserNotificationEventListener.java
@@ -24,8 +24,11 @@ public class ChatUserNotificationEventListener {
                 destination
         );
 
-        // TODO: UserDestination 설정이 안정화되면
-        // /user/queue/notifications 방식으로 전환
+        /*
+        * TODO: UserDestination 설정이 안정화되면
+        *  /user/queue/notifications 방식으로 전환
+        * */
+        // 사용자별 채팅 목록 갱신 알림 전송
         messagingTemplate.convertAndSend(
                 destination,
                 event.payload()

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
@@ -81,20 +81,24 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                 currentUserId
         );
 
+        // 채팅방 메시지 브로드캐스트용 이벤트 발행
         eventPublisher.publishEvent(
                 new ChatRoomBroadcastEvent(chatRoom.getId(), response)
         );
 
+        // 채팅방 참여자별 채팅 목록 갱신 알림 이벤트 발행
         List<ChatPart> participants =
                 chatPartRepository.findActiveParticipantsWithUserByChatRoomId(chatRoom.getId());
 
         for (ChatPart participant : participants) {
             Long receiverId = participant.getUser().getId();
 
+            // 발신자는 제외
             if (receiverId.equals(currentUserId)) {
                 continue;
             }
 
+            // 수신자 기준 안 읽은 메시지 개수 계산
             Long unreadCount = messageRepository.countUnreadMessagesByChatRoomId(
                     chatRoom.getId(),
                     receiverId
@@ -121,6 +125,7 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                     currentUserId
             );
 
+            // 채팅 목록(lastMessage, unreadCount) 갱신용 개인 알림 이벤트 발행
             eventPublisher.publishEvent(
                     new ChatUserNotificationEvent(receiverId, notification)
             );

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
@@ -2,8 +2,10 @@ package com.capstone.pickIt.api.chat.service;
 
 import com.capstone.pickIt.api.chat.converter.ChatRoomEventConverter;
 import com.capstone.pickIt.api.chat.dto.request.ChatMessageSendRequestDTO;
+import com.capstone.pickIt.api.chat.dto.response.ChatNotificationResponseDTO;
 import com.capstone.pickIt.api.chat.dto.response.ChatRoomEventResponseDTO;
 import com.capstone.pickIt.api.chat.event.ChatRoomBroadcastEvent;
+import com.capstone.pickIt.api.chat.event.ChatUserNotificationEvent;
 import com.capstone.pickIt.domain.chat.entity.*;
 import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
@@ -14,6 +16,7 @@ import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ChatMessageCommandServiceImpl implements ChatMessageCommandService {
 
     private final ChatRoomRepository chatRoomRepository;
@@ -70,9 +74,57 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                         unreadMemberCount
                 );
 
+        log.info(
+                "Publishing chat message event: chatRoomId={}, chatType={}, senderId={}",
+                chatRoom.getId(),
+                chatRoom.getChatType(),
+                currentUserId
+        );
+
         eventPublisher.publishEvent(
                 new ChatRoomBroadcastEvent(chatRoom.getId(), response)
         );
+
+        List<ChatPart> participants =
+                chatPartRepository.findActiveParticipantsWithUserByChatRoomId(chatRoom.getId());
+
+        for (ChatPart participant : participants) {
+            Long receiverId = participant.getUser().getId();
+
+            if (receiverId.equals(currentUserId)) {
+                continue;
+            }
+
+            Long unreadCount = messageRepository.countUnreadMessagesByChatRoomId(
+                    chatRoom.getId(),
+                    receiverId
+            );
+
+            ChatNotificationResponseDTO.ChatRoomNotification notification =
+                    new ChatNotificationResponseDTO.ChatRoomNotification(
+                            "CHAT_MESSAGE_RECEIVED",
+                            chatRoom.getId(),
+                            chatRoom.getChatType(),
+                            message.getId(),
+                            message.getMessageType(),
+                            message.getContent(),
+                            message.getCreatedAt(),
+                            sender.getId(),
+                            sender.getNickname(),
+                            unreadCount
+                    );
+
+            log.info(
+                    "Publishing chat user notification: chatRoomId={}, receiverId={}, senderId={}",
+                    chatRoom.getId(),
+                    receiverId,
+                    currentUserId
+            );
+
+            eventPublisher.publishEvent(
+                    new ChatUserNotificationEvent(receiverId, notification)
+            );
+        }
     }
 
     private void validateMessagePayload(ChatMessageSendRequestDTO request) {

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
@@ -9,10 +9,7 @@ import com.capstone.pickIt.api.chat.event.ChatUserNotificationEvent;
 import com.capstone.pickIt.domain.chat.entity.*;
 import com.capstone.pickIt.domain.chat.exception.ChatErrorCode;
 import com.capstone.pickIt.domain.chat.exception.ChatException;
-import com.capstone.pickIt.domain.chat.repository.ChatPartRepository;
-import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
-import com.capstone.pickIt.domain.chat.repository.MessageFileRepository;
-import com.capstone.pickIt.domain.chat.repository.MessageRepository;
+import com.capstone.pickIt.domain.chat.repository.*;
 import com.capstone.pickIt.domain.user.entity.User;
 import com.capstone.pickIt.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,15 +51,20 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
         User sender = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CURRENT_USER_NOT_FOUND));
 
+        // 메시지 타입별 요청 데이터 검증
         validateMessagePayload(request);
 
+        // 메시지 저장
         Message message = createMessage(chatRoom, sender, request);
         messageRepository.saveAndFlush(message);
 
+        // 첨부파일 저장
         List<MessageFile> files = saveMessageFiles(message, request);
 
+        // 채팅방 마지막 메시지 정보 갱신
         chatRoom.updateLastMessage(message);
 
+        // 발신자를 제외한 안 읽은 참여자 수 계산
         int unreadMemberCount = Math.max(
                 0,
                 chatPartRepository.countActiveParticipants(chatRoom.getId()) - 1
@@ -81,14 +85,30 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                 currentUserId
         );
 
-        // 채팅방 메시지 브로드캐스트용 이벤트 발행
+        /*
+         * 채팅방 메시지 브로드캐스트용 이벤트 발행
+         */
         eventPublisher.publishEvent(
                 new ChatRoomBroadcastEvent(chatRoom.getId(), response)
         );
 
-        // 채팅방 참여자별 채팅 목록 갱신 알림 이벤트 발행
+        /*
+         * 채팅방 참여자별 채팅 목록 갱신 알림 이벤트 발행
+         */
         List<ChatPart> participants =
                 chatPartRepository.findActiveParticipantsWithUserByChatRoomId(chatRoom.getId());
+
+        // 수신자별 안 읽은 메시지 개수 한 번에 조회
+        Map<Long, Long> unreadCountMap =
+                messageRepository.countUnreadMessagesByUsersInChatRoom(
+                                chatRoom.getId(),
+                                currentUserId
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                UnreadCountByUserProjection::getUserId,
+                                UnreadCountByUserProjection::getUnreadCount
+                        ));
 
         for (ChatPart participant : participants) {
             Long receiverId = participant.getUser().getId();
@@ -98,11 +118,7 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                 continue;
             }
 
-            // 수신자 기준 안 읽은 메시지 개수 계산
-            Long unreadCount = messageRepository.countUnreadMessagesByChatRoomId(
-                    chatRoom.getId(),
-                    receiverId
-            );
+            Long unreadCount = unreadCountMap.getOrDefault(receiverId, 0L);
 
             ChatNotificationResponseDTO.ChatRoomNotification notification =
                     new ChatNotificationResponseDTO.ChatRoomNotification(

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
@@ -120,6 +120,10 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
 
             Long unreadCount = unreadCountMap.getOrDefault(receiverId, 0L);
 
+            String lastMessage = message.getMessageType() == MessageType.FILE
+                    ? "파일을 보냈습니다."
+                    : message.getContent();
+
             ChatNotificationResponseDTO.ChatRoomNotification notification =
                     new ChatNotificationResponseDTO.ChatRoomNotification(
                             "CHAT_MESSAGE_RECEIVED",
@@ -127,7 +131,7 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                             chatRoom.getChatType(),
                             message.getId(),
                             message.getMessageType(),
-                            message.getContent(),
+                            lastMessage,
                             message.getCreatedAt(),
                             sender.getId(),
                             sender.getNickname(),

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.capstone.pickIt.domain.chat.repository.ChatRoomRepository;
 import com.capstone.pickIt.domain.chat.repository.MessageFileRepository;
 import com.capstone.pickIt.domain.chat.repository.MessageRepository;
 import com.capstone.pickIt.domain.course.entity.Course;
+import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
 import com.capstone.pickIt.domain.course.repository.UserCourseProfileRepository;
 import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import com.capstone.pickIt.domain.project.repository.TeamRequestRepository;
@@ -72,20 +73,29 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
         Long opponentUserId = opponentChatPart.getUser().getId();
 
-        boolean existsPendingForReceiver =
-                teamRequestRepository.existsBySenderIdAndReceiverIdAndTeamRequestStatus(
+        // 현재 두 사용자 사이에 PENDING 팀원 요청이 존재하면
+        // 추가 요청을 보내지 못하도록 공통 과목 목록 전체를 빈 배열로 반환
+        boolean existsPendingBetweenUsers =
+                teamRequestRepository.existsPendingBetweenUsers(
                         currentUserId,
                         opponentUserId,
                         TeamRequestStatus.PENDING
                 );
 
-        if (existsPendingForReceiver) {
+        if (existsPendingBetweenUsers) {
             return new CommonCourseResponseDTO.CommonCourseList(List.of());
         }
 
+        // 요청 가능한 공통 과목 조회
+        // - 현재 사용자가 다른 사용자에게 이미 PENDING 요청을 보낸 과목은 제외
+        // - 현재 상대방과 이미 ACCEPTED 된 과목은 양쪽 모두에게 제외
+        // - 두 사용자 모두 RECRUITING 상태인 공통 과목만 조회
         List<Course> commonCourses = userCourseProfileRepository.findRequestableCommonCourses(
                 currentUserId,
-                opponentChatPart.getUser().getId()
+                opponentUserId,
+                RecruitmentStatus.RECRUITING,
+                TeamRequestStatus.PENDING,
+                TeamRequestStatus.ACCEPTED
         );
 
         return CommonCourseConverter.toCommonCourseList(commonCourses);

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -141,4 +141,15 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             @Param("chatRoomId") Long chatRoomId,
             @Param("messageIds") List<Long> messageIds
     );
+
+    @Query("""
+        SELECT cp
+        FROM ChatPart cp
+        JOIN FETCH cp.user
+        WHERE cp.chatRoom.id = :chatRoomId
+            AND cp.deletedAt IS NULL
+    """)
+    List<ChatPart> findActiveParticipantsWithUserByChatRoomId(
+            @Param("chatRoomId") Long chatRoomId
+    );
 }

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/MessageRepository.java
@@ -56,6 +56,27 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     );
 
     @Query("""
+        SELECT cp.user.id AS userId,
+           COUNT(m.id) AS unreadCount
+        FROM ChatPart cp
+        LEFT JOIN Message m
+        ON m.chatRoom.id = cp.chatRoom.id
+            AND m.user.id <> cp.user.id
+            AND (
+                cp.lastReadMessage IS NULL
+                OR m.id > cp.lastReadMessage.id
+                )
+        WHERE cp.chatRoom.id = :chatRoomId
+            AND cp.deletedAt IS NULL
+            AND cp.user.id <> :senderId
+        GROUP BY cp.user.id
+    """)
+    List<UnreadCountByUserProjection> countUnreadMessagesByUsersInChatRoom(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("senderId") Long senderId
+    );
+
+    @Query("""
         SELECT m
         FROM Message m
         JOIN FETCH m.user

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/UnreadCountByUserProjection.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/UnreadCountByUserProjection.java
@@ -1,0 +1,6 @@
+package com.capstone.pickIt.domain.chat.repository;
+
+public interface UnreadCountByUserProjection {
+    Long getUserId();
+    Long getUnreadCount();
+}

--- a/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/course/repository/UserCourseProfileRepository.java
@@ -3,6 +3,7 @@ package com.capstone.pickIt.domain.course.repository;
 import com.capstone.pickIt.domain.course.entity.Course;
 import com.capstone.pickIt.domain.course.entity.RecruitmentStatus;
 import com.capstone.pickIt.domain.course.entity.UserCourseProfile;
+import com.capstone.pickIt.domain.project.entity.TeamRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,20 +30,34 @@ public interface UserCourseProfileRepository extends JpaRepository<UserCoursePro
           AND ucp2.user.id = :opponentUserId
           AND ucp1.deletedAt IS NULL
           AND ucp2.deletedAt IS NULL
-          AND ucp1.recruitmentStatus = 'RECRUITING'
-          AND ucp2.recruitmentStatus = 'RECRUITING'
+          AND ucp1.recruitmentStatus = :recruitingStatus
+          AND ucp2.recruitmentStatus = :recruitingStatus
           AND NOT EXISTS (
               SELECT 1
               FROM TeamRequest tr
               WHERE tr.sender.id = :currentUserId
                 AND tr.course.id = ucp1.course.id
-                AND tr.teamRequestStatus = 'PENDING'
+                AND tr.teamRequestStatus = :pendingStatus
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM TeamRequest tr
+              WHERE tr.course.id = ucp1.course.id
+                AND tr.teamRequestStatus = :acceptedStatus
+                AND (
+                  (tr.sender.id = :currentUserId AND tr.receiver.id = :opponentUserId)
+                  OR
+                  (tr.sender.id = :opponentUserId AND tr.receiver.id = :currentUserId)
+                )
           )
         ORDER BY ucp1.course.courseName ASC
         """)
     List<Course> findRequestableCommonCourses(
-            Long currentUserId,
-            Long opponentUserId
+            @Param("currentUserId") Long currentUserId,
+            @Param("opponentUserId") Long opponentUserId,
+            @Param("recruitingStatus") RecruitmentStatus recruitingStatus,
+            @Param("pendingStatus") TeamRequestStatus pendingStatus,
+            @Param("acceptedStatus") TeamRequestStatus acceptedStatus
     );
 
     Optional<UserCourseProfile> findByUserIdAndCourseIdAndDeletedAtIsNull(

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -22,16 +22,26 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             TeamRequestStatus teamRequestStatus
     );
 
-    boolean existsBySenderIdAndReceiverIdAndTeamRequestStatus(
-            Long senderId,
-            Long receiverId,
-            TeamRequestStatus teamRequestStatus
-    );
-
     Page<TeamRequest> findByTeamRequestStatusAndCreatedAtLessThanEqual(
             TeamRequestStatus teamRequestStatus,
             LocalDateTime createdAt,
             Pageable pageable
+    );
+
+    @Query("""
+        SELECT COUNT(tr) > 0
+        FROM TeamRequest tr
+        WHERE tr.teamRequestStatus = :status
+        AND (
+            (tr.sender.id = :userId AND tr.receiver.id = :opponentUserId)
+            OR
+            (tr.sender.id = :opponentUserId AND tr.receiver.id = :userId)
+        )
+    """)
+    boolean existsPendingBetweenUsers(
+            @Param("userId") Long userId,
+            @Param("opponentUserId") Long opponentUserId,
+            @Param("status") TeamRequestStatus status
     );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/TeamRequestRepository.java
@@ -22,6 +22,12 @@ public interface TeamRequestRepository extends JpaRepository<TeamRequest, Long> 
             TeamRequestStatus teamRequestStatus
     );
 
+    boolean existsBySenderIdAndReceiverIdAndTeamRequestStatus(
+            Long senderId,
+            Long receiverId,
+            TeamRequestStatus teamRequestStatus
+    );
+
     Page<TeamRequest> findByTeamRequestStatusAndCreatedAtLessThanEqual(
             TeamRequestStatus teamRequestStatus,
             LocalDateTime createdAt,

--- a/src/main/java/com/capstone/pickIt/global/config/security/AuthPrincipal.java
+++ b/src/main/java/com/capstone/pickIt/global/config/security/AuthPrincipal.java
@@ -3,9 +3,11 @@ package com.capstone.pickIt.global.config.security;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.security.Principal;
+
 @Getter
 @AllArgsConstructor
-public class AuthPrincipal {
+public class AuthPrincipal{
     private final Long userId;
     private final String email;
 }

--- a/src/main/java/com/capstone/pickIt/global/config/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/capstone/pickIt/global/config/websocket/StompAuthChannelInterceptor.java
@@ -40,16 +40,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
             Long userId = jwtProvider.getUserId(authorization);
             String email = jwtProvider.getEmail(authorization);
 
-            AuthPrincipal principal = new AuthPrincipal(userId, email);
-
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            principal,
-                            null,
-                            Collections.emptyList()
-                    );
-
-            accessor.setUser(authentication);
+            accessor.setUser(() -> userId.toString());
 
             Map<String, Object> sessionAttrs = accessor.getSessionAttributes();
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #152 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### WebSocket 기반 채팅 목록 갱신 알림 추가
- 채팅 메시지 전송 시 채팅방 구독자 대상 메시지 브로드캐스트와 별도로, 채팅 목록 갱신용 개인 알림 이벤트를 추가했습니다.
  - 채팅방 참여자(발신자 제외)에게 채팅 목록 갱신 알림 전송
  - 채팅 목록 갱신에 필요한 lastMessage, lastMessageAt, unreadCount 정보 전달

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- 단체 채팅방 메시지 전송 시 /topic/chatrooms/{chatRoomId} 브로드캐스트 수신 확인
- 채팅 목록 갱신용 알림(/queue/notifications/{userId}) 수신 확인
<img width="2846" height="1566" alt="화면 캡처 2026-05-30 012312" src="https://github.com/user-attachments/assets/d9f777ac-80fb-4949-b2fc-865153877bb5" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 현재는 /queue/notifications/{userId} 방식으로 구현했습니다.
- 추후 Spring User Destination(/user/queue/notifications) 방식으로 전환할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 사용자별 실시간 채팅 알림 시스템 추가
  * 미읽음 메시지 카운트를 포함한 알림 기능 구현

* **Bug Fixes**
  * 팀 요청 상태 확인 시 양방향 검증 로직 강화

* **Chores**
  * 채팅 로깅 기능 개선
  * WebSocket 사용자 인증 처리 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capstone-pick-it/Backend/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->