### PR TITLE
[Feat] 채팅 메시지 읽음 이벤트 브로드캐스트 추가

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomEventConverter.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/converter/ChatRoomEventConverter.java
@@ -35,6 +35,7 @@ public class ChatRoomEventConverter {
                         message.getCreatedAt(),
                         unreadMemberCount
                 ),
+                null,
                 null
         );
     }
@@ -54,7 +55,8 @@ public class ChatRoomEventConverter {
                         teamRequest.getTeamRequestStatus().name(),
                         teamRequest.getCreatedAt(),
                         null
-                )
+                ),
+                null
         );
     }
 
@@ -73,7 +75,8 @@ public class ChatRoomEventConverter {
                         teamRequest.getTeamRequestStatus().name(),
                         teamRequest.getCreatedAt(),
                         teamRequest.getRespondedAt()
-                )
+                ),
+                null
         );
     }
 
@@ -92,6 +95,25 @@ public class ChatRoomEventConverter {
                         teamRequest.getTeamRequestStatus().name(),
                         teamRequest.getCreatedAt(),
                         teamRequest.getRespondedAt()
+                ),
+                null
+        );
+    }
+
+    public static ChatRoomEventResponseDTO.ChatRoomEvent toMessageReadEvent(
+            ChatRoom chatRoom,
+            Long readerId,
+            Long lastReadMessageId
+    ) {
+        return new ChatRoomEventResponseDTO.ChatRoomEvent(
+                ChatEventType.CHAT_MESSAGE_READ.name(),
+                chatRoom.getId(),
+                chatRoom.getChatType().name(),
+                null,
+                null,
+                new ChatRoomEventResponseDTO.MessageReadPayload(
+                        readerId,
+                        lastReadMessageId
                 )
         );
     }

--- a/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomEventResponseDTO.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/dto/response/ChatRoomEventResponseDTO.java
@@ -10,7 +10,8 @@ public class ChatRoomEventResponseDTO {
             Long chatRoomId,
             String chatType,
             MessagePayload message,
-            TeamRequestPayload teamRequest
+            TeamRequestPayload teamRequest,
+            MessageReadPayload messageRead
     ) {
     }
 
@@ -47,6 +48,12 @@ public class ChatRoomEventResponseDTO {
             String status,
             LocalDateTime createdAt,
             LocalDateTime respondedAt
+    ) {
+    }
+
+    public record MessageReadPayload(
+            Long readerId,
+            Long lastReadMessageId
     ) {
     }
 }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -179,9 +179,22 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
                 .findByIdAndChatRoomId(request.lastReadMessageId(), chatRoomId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.MESSAGE_NOT_FOUND));
 
-        if (chatPart.getLastReadMessage() == null
-                || chatPart.getLastReadMessage().getId() < message.getId()) {
+        boolean isUpdated = chatPart.getLastReadMessage() == null
+                || chatPart.getLastReadMessage().getId() < message.getId();
+
+        if (isUpdated) {
             chatPart.updateLastReadMessage(message);
+
+            ChatRoomEventResponseDTO.ChatRoomEvent readEvent =
+                    ChatRoomEventConverter.toMessageReadEvent(
+                            message.getChatRoom(),
+                            currentUserId,
+                            message.getId()
+                    );
+
+            eventPublisher.publishEvent(
+                    new ChatRoomBroadcastEvent(chatRoomId, readEvent)
+            );
         }
 
         Long unreadCount = messageRepository.countUnreadMessagesByChatRoomId(chatRoomId, currentUserId);

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -38,7 +38,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.capstone.pickIt.domain.point.policy.PointPolicy.PROJECT_REQUIRED_POINT;
@@ -199,9 +198,13 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
 
         Long unreadCount = messageRepository.countUnreadMessagesByChatRoomId(chatRoomId, currentUserId);
 
+        Long lastReadMessageId = chatPart.getLastReadMessage() != null
+                ? chatPart.getLastReadMessage().getId()
+                : message.getId();
+
         return new ChatMessageResponseDTO.ReadUpdateResponse(
                 chatRoomId,
-                chatPart.getLastReadMessage().getId(),
+                lastReadMessageId,
                 unreadCount
         );
     }
@@ -228,7 +231,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
         }
 
         ChatPart receiverChatPart = chatPartRepository
-                .findOpponent(chatRoomId, currentUserId)
+                .findActiveOpponent(chatRoomId, currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
 
         User sender = currentChatPart.getUser();

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -68,7 +68,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         }
 
         ChatPart opponentChatPart = chatPartRepository
-                .findOpponent(chatRoomId, currentUserId)
+                .findActiveOpponent(chatRoomId, currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
 
         Long opponentUserId = opponentChatPart.getUser().getId();

--- a/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatEventType.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/entity/ChatEventType.java
@@ -2,6 +2,7 @@ package com.capstone.pickIt.domain.chat.entity;
 
 public enum ChatEventType {
     CHAT_MESSAGE_CREATED,
+    CHAT_MESSAGE_READ,
     TEAM_REQUEST_CREATED,
     TEAM_REQUEST_ACCEPTED,
     TEAM_REQUEST_REJECTED

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -10,9 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
     Optional<ChatPart> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
@@ -24,6 +22,18 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             WHERE cp.chatRoom.id = :chatRoomId
               AND cp.user.id <> :currentUserId
               AND cp.deletedAt IS NULL
+            """)
+    Optional<ChatPart> findActiveOpponent(
+            Long chatRoomId,
+            Long currentUserId
+    );
+
+    @Query("""
+            SELECT cp
+            FROM ChatPart cp
+            JOIN FETCH cp.user
+            WHERE cp.chatRoom.id = :chatRoomId
+              AND cp.user.id <> :currentUserId
             """)
     Optional<ChatPart> findOpponent(
             Long chatRoomId,
@@ -110,7 +120,6 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
         FROM ChatPart cp
         WHERE cp.chatRoom.id IN :chatRoomIds
         AND cp.user.id <> :currentUserId
-        AND cp.deletedAt IS NULL
     """)
     List<OpponentProjection> findOpponentsByChatRoomIds(
             @Param("chatRoomIds") List<Long> chatRoomIds,


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #158 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 채팅 메시지 읽음 처리 시 `CHAT_MESSAGE_READ` 이벤트 브로드캐스트 추가
  - 채팅방 내부에서 읽지 않은 인원 수(`unreadMemberCount`)를 실시간으로 갱신할 수 있도록 이벤트 발행
- 채팅 목록 조회 시 상대방이 채팅방을 나간 상태여도 상대방 정보가 조회되도록 수정
- 채팅 메시지 목록 조회 시 상대방이 채팅방을 나간 상태여도 상대방 정보가 조회되도록 수정

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **New Features**
  * 메시지 읽음 상태 추적 및 실시간 이벤트 브로드캐스팅 기능 추가. 사용자가 메시지를 읽을 때 상대방에게 즉시 알림.

* **Improvements**
  * 활성 사용자와의 상호작용만 처리하도록 개선하여 채팅 환경의 정합성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->