### PR TITLE
[Fix] 프로젝트 이력 조회 시 DONE 상태 팀만 필터링

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/user/service/MypageProjectHistoryService.java
+++ b/src/main/java/com/capstone/pickIt/api/user/service/MypageProjectHistoryService.java
@@ -4,7 +4,7 @@ import com.capstone.pickIt.api.user.dto.response.ProjectHistoryDetailResponseDTO
 import com.capstone.pickIt.api.user.dto.response.ProjectHistorySummaryResponseDTO;
 import com.capstone.pickIt.domain.project.entity.ProjectTeam;
 import com.capstone.pickIt.domain.project.entity.ProjectTeamMember;
-import com.capstone.pickIt.domain.project.entity.RecruitmentConfirmStatus;
+import com.capstone.pickIt.domain.project.entity.ProjectTeamStatus;
 import com.capstone.pickIt.domain.project.repository.PeerReviewRepository;
 import com.capstone.pickIt.domain.project.repository.ProjectTeamMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -46,8 +46,8 @@ public class MypageProjectHistoryService {
     @Transactional(readOnly = true)
     public ProjectHistoryDetailResponseDTO getProjectHistoryDetail(Long userId) {
         List<ProjectTeamMember> members = projectTeamMemberRepository
-                .findAllByUserIdAndRecruitmentConfirmStatusAndLeftAtIsNullOrderByJoinedAtDesc(
-                        userId, RecruitmentConfirmStatus.CONFIRMED);
+                .findActiveConfirmedMembershipsWithTeamAndCourse(
+                        userId, ProjectTeamStatus.DONE);
 
         double averageCompletionRate = members.stream()
                 .mapToDouble(m -> m.getProjectTeam().getProgressRate() != null


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
161
closes #161

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
프로젝트 이력 조회 시 DONE 상태 팀만 필터링


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 마이페이지 프로젝트 히스토리 상세 조회에서 팀 상태 기준으로 구성원 및 팀 정보를 더 정확하게 조회하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->