### PR TITLE
[Fix] DIRECT 채팅방 재입장 및 메시지 전송 시 ChatPart 복구

### DIFF
--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatMessageCommandServiceImpl.java
@@ -155,6 +155,12 @@ public class ChatMessageCommandServiceImpl implements ChatMessageCommandService 
                     currentUserId
             );
 
+            // DIRECT 채팅 상대방이 나간 상태라면 채팅방 재노출을 위해 복구
+            if (chatRoom.getChatType() == ChatType.DIRECT) {
+                chatPartRepository.findOpponentIncludingDeleted(chatRoom.getId(), currentUserId)
+                        .ifPresent(ChatPart::restore);
+            }
+
             // 채팅 목록(lastMessage, unreadCount) 갱신용 개인 알림 이벤트 발행
             eventPublisher.publishEvent(
                     new ChatUserNotificationEvent(receiverId, notification)

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomCommandServiceImpl.java
@@ -378,7 +378,12 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService {
                 .findByChatRoomIdAndUserId(chatRoom.getId(), currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
 
+        ChatPart targetChatPart = chatPartRepository
+                .findByChatRoomIdAndUserId(chatRoom.getId(), targetUser.getId())
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
+
         currentChatPart.restore();
+        targetChatPart.restore();
 
         return ChatRoomConverter.toCreateOrEnterResponse(chatRoom, targetUser, isNew);
     }

--- a/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/capstone/pickIt/api/chat/service/ChatRoomQueryServiceImpl.java
@@ -436,7 +436,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         }
 
         ChatPart opponentChatPart = chatPartRepository
-                .findOpponent(chatRoomId, currentUserId)
+                .findOpponentIncludingDeleted(chatRoomId, currentUserId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_PART_NOT_FOUND));
 
         return ChatMessageConverter.toOpponent(opponentChatPart);

--- a/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/chat/repository/ChatPartRepository.java
@@ -35,7 +35,7 @@ public interface ChatPartRepository extends JpaRepository<ChatPart, Long> {
             WHERE cp.chatRoom.id = :chatRoomId
               AND cp.user.id <> :currentUserId
             """)
-    Optional<ChatPart> findOpponent(
+    Optional<ChatPart> findOpponentIncludingDeleted(
             Long chatRoomId,
             Long currentUserId
     );


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #170 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- DIRECT 채팅방 재입장 및 메시지 전송 시 ChatPart 복구


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 1:1 채팅에서 삭제된 채팅방이 메시지 수신 시 자동으로 복구되도록 개선

* **개선사항**
  * 채팅방 진입 시 상대방의 삭제된 채팅 참여 정보를 복구하는 로직 추가
  * 삭제된 상태의 상대방 정보도 정상적으로 조회할 수 있도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->