### PR TITLE
[Refactor] 팀 요청 모집 탭 수정

### DIFF
--- a/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
+++ b/src/main/java/com/capstone/pickIt/domain/project/repository/ProjectTeamMemberRepository.java
@@ -96,7 +96,7 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
         JOIN FETCH ptm.projectTeam pt
         JOIN FETCH pt.course
         WHERE ptm.user.id = :userId
-          AND ptm.recruitmentConfirmStatus = 'CONFIRMED'
+          AND ptm.recruitmentConfirmStatus IN ('CONFIRMED', 'PENDING')
           AND ptm.leftAt IS NULL
           AND (:status IS NULL OR pt.status = :status)
         ORDER BY ptm.joinedAt DESC
@@ -112,7 +112,7 @@ public interface ProjectTeamMemberRepository extends JpaRepository<ProjectTeamMe
         JOIN FETCH ptm.user
         WHERE ptm.projectTeam.id IN :projectTeamIds
           AND ptm.leftAt IS NULL
-          AND ptm.recruitmentConfirmStatus = 'CONFIRMED'
+          AND ptm.recruitmentConfirmStatus IN ('CONFIRMED', 'PENDING')
         ORDER BY ptm.projectTeam.id, ptm.joinedAt ASC
     """)
     List<ProjectTeamMember> findActiveConfirmedMembersWithUserByProjectTeamIds(


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

  - 팀 요청 수락 후 확정 버튼을 누르지 않은 PENDING 상태 팀원이 모집중 탭(GET /api/projects?status=RECRUITING)에서 프로젝트를 조회할 수 없는 버그 수정                                                                        - ProjectTeamMemberRepository의 쿼리 조건을 = 'CONFIRMED'에서 IN ('CONFIRMED', 'PENDING')으로 변경                                                                                                                                                                                                                                                                                                                                                      변경 파일                                                                                                                                                                                                                                                                                                                                                                                                                                             
  ProjectTeamMemberRepository.java

  - findActiveConfirmedMembershipsWithTeamAndCourse — 내 프로젝트 목록 조회 시 PENDING 상태도 포함
  - findActiveConfirmedMembersWithUserByProjectTeamIds — 프로젝트 카드 팀원 이름 목록도 PENDING 포함


  팀 요청 수락 → recruitmentConfirmStatus = PENDING
  확정 버튼 클릭 → CONFIRMED

  기존 쿼리가 CONFIRMED만 필터링하여, 수락 후 확정 전(PENDING) 팀원은 모집중 탭에서 프로젝트가 보이지 않았음. 

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 팀 구성원 조회 시 승인 대기 중인 구성원도 포함하여 표시되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->